### PR TITLE
Added a help command

### DIFF
--- a/commands/apply.js
+++ b/commands/apply.js
@@ -28,6 +28,6 @@ ${clan.formUrl}`;
 module.exports.config = {
 	name: 'apply',
 	aliases: ['apply', 'applyto'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    description: 'I will send you an application form for the clan you wish to join.',
+    usage: [`apply clan`]
 };

--- a/commands/apply.js
+++ b/commands/apply.js
@@ -28,6 +28,6 @@ ${clan.formUrl}`;
 module.exports.config = {
 	name: 'apply',
 	aliases: ['apply', 'applyto'],
-    description: 'I will send you an application form for the clan you wish to join.',
-    usage: [`apply clan`]
+	description: 'I will send you an application form for the clan you wish to join.',
+	usage: ['apply clan']
 };

--- a/commands/apply.js
+++ b/commands/apply.js
@@ -28,4 +28,6 @@ ${clan.formUrl}`;
 module.exports.config = {
 	name: 'apply',
 	aliases: ['apply', 'applyto'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/choose.js
+++ b/commands/choose.js
@@ -16,6 +16,6 @@ module.exports.execute = async (client, message, args) => {
 module.exports.config = {
 	name: 'choose',
 	aliases: ['choose', 'pick'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    description: 'I will choose one of your options at random.',
+    usage: [`choose option1, option2, ..., optionX`]
 };

--- a/commands/choose.js
+++ b/commands/choose.js
@@ -15,5 +15,7 @@ module.exports.execute = async (client, message, args) => {
 
 module.exports.config = {
 	name: 'choose',
-	aliases: ['choose', 'pick']
+	aliases: ['choose', 'pick'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/choose.js
+++ b/commands/choose.js
@@ -16,6 +16,6 @@ module.exports.execute = async (client, message, args) => {
 module.exports.config = {
 	name: 'choose',
 	aliases: ['choose', 'pick'],
-    description: 'I will choose one of your options at random.',
-    usage: [`choose option1, option2, ..., optionX`]
+	description: 'I will choose one of your options at random.',
+	usage: ['choose option1, option2, ..., optionX']
 };

--- a/commands/clans.js
+++ b/commands/clans.js
@@ -16,4 +16,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'clans',
 	aliases: ['clanlist', 'clans'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/clans.js
+++ b/commands/clans.js
@@ -16,6 +16,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'clans',
 	aliases: ['clanlist', 'clans'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    description: 'I will list all the clans for you.',
+    usage: [`clans`]
 };

--- a/commands/clans.js
+++ b/commands/clans.js
@@ -16,6 +16,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'clans',
 	aliases: ['clanlist', 'clans'],
-    description: 'I will list all the clans for you.',
-    usage: [`clans`]
+	description: 'I will list all the clans for you.',
+	usage: ['clans']
 };

--- a/commands/coinflip.js
+++ b/commands/coinflip.js
@@ -6,5 +6,7 @@ module.exports.execute = async (client, message) => {
 
 module.exports.config = {
 	name: 'coinflip',
-	aliases: ['flipcoin', 'coinflip']
+	aliases: ['flipcoin', 'coinflip'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/coinflip.js
+++ b/commands/coinflip.js
@@ -7,6 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'coinflip',
 	aliases: ['flipcoin', 'coinflip'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    description: 'We will flip a coin together. Heads or tails?',
+    usage: [`coinflip`]
 };

--- a/commands/coinflip.js
+++ b/commands/coinflip.js
@@ -7,6 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'coinflip',
 	aliases: ['flipcoin', 'coinflip'],
-    description: 'We will flip a coin together. Heads or tails?',
-    usage: [`coinflip`]
+	description: 'We will flip a coin together. Heads or tails?',
+	usage: ['coinflip']
 };

--- a/commands/cotw.js
+++ b/commands/cotw.js
@@ -14,5 +14,5 @@ module.exports.config = {
 	name: 'cotw',
 	aliases: ['cotw'],
     description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    usage: [`TEMPLATE`]
 };

--- a/commands/cotw.js
+++ b/commands/cotw.js
@@ -13,6 +13,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'cotw',
 	aliases: ['cotw'],
-    description: 'I will tell you what the challenge of the week is.',
-    usage: [`cotw`]
+	description: 'I will tell you what the challenge of the week is.',
+	usage: ['cotw']
 };

--- a/commands/cotw.js
+++ b/commands/cotw.js
@@ -12,5 +12,7 @@ module.exports.execute = async (client, message) => {
 
 module.exports.config = {
 	name: 'cotw',
-	aliases: ['cotw']
+	aliases: ['cotw'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/cotw.js
+++ b/commands/cotw.js
@@ -13,6 +13,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'cotw',
 	aliases: ['cotw'],
-    description: 'TEMPLATE',
-    usage: [`TEMPLATE`]
+    description: 'I will tell you what the challenge of the week is.',
+    usage: [`cotw`]
 };

--- a/commands/dice.js
+++ b/commands/dice.js
@@ -1,3 +1,6 @@
+
+const prefix = require('../config.json').prefix;
+
 module.exports.execute = async (client, message, args) => {
 	if(!args || !args.length === 0 ) {
 		return await message.channel.send('❌ Please specify the dice size.');
@@ -16,4 +19,6 @@ module.exports.execute = async (client, message, args) => {
 module.exports.config = {
 	name: 'dice',
 	aliases: ['dice'],
+	description: 'Roll the dice for a random number.',
+	usage: [`${prefix}dice <sides>`]
 };

--- a/commands/dice.js
+++ b/commands/dice.js
@@ -17,5 +17,5 @@ module.exports.config = {
 	name: 'dice',
 	aliases: ['dice'],
 	description: 'Roll the dice for a random number.',
-	usage: [`dice <sides>`]
+	usage: ['dice <sides>']
 };

--- a/commands/dice.js
+++ b/commands/dice.js
@@ -1,6 +1,3 @@
-
-const prefix = require('../config.json').prefix;
-
 module.exports.execute = async (client, message, args) => {
 	if(!args || !args.length === 0 ) {
 		return await message.channel.send('❌ Please specify the dice size.');
@@ -20,5 +17,5 @@ module.exports.config = {
 	name: 'dice',
 	aliases: ['dice'],
 	description: 'Roll the dice for a random number.',
-	usage: [`${prefix}dice <sides>`]
+	usage: [`dice <sides>`]
 };

--- a/commands/facebook.js
+++ b/commands/facebook.js
@@ -7,6 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'facebook',
 	aliases: ['facebook', 'fb'],
-    description: 'I will send you the link to our facebook group.',
-    usage: [`facebook`]
+	description: 'I will send you the link to our facebook group.',
+	usage: ['facebook']
 };

--- a/commands/facebook.js
+++ b/commands/facebook.js
@@ -7,6 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'facebook',
 	aliases: ['facebook', 'fb'],
-    description: 'TEMPLATE',
-    usage: [`TEMPLATE`]
+    description: 'I will send you the link to our facebook group.',
+    usage: [`facebook`]
 };

--- a/commands/facebook.js
+++ b/commands/facebook.js
@@ -7,6 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'facebook',
 	aliases: ['facebook', 'fb'],
-	description: 'I will send you the link to our facebook group.',
+	description: 'I will send you the link to our Facebook group.',
 	usage: ['facebook']
 };

--- a/commands/facebook.js
+++ b/commands/facebook.js
@@ -8,5 +8,5 @@ module.exports.config = {
 	name: 'facebook',
 	aliases: ['facebook', 'fb'],
     description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    usage: [`TEMPLATE`]
 };

--- a/commands/facebook.js
+++ b/commands/facebook.js
@@ -7,4 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'facebook',
 	aliases: ['facebook', 'fb'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -33,7 +33,7 @@ module.exports.execute = async (client, message, args) => {
 		if (command) {
 			let helpMessage = [`__**Help for the ${command.config.name} command:**__\n\n`];
 			helpMessage.push(command.config.description, '\n\n');
-			helpMessage.push('Aliasses: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
+			helpMessage.push('Aliases: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
 			helpMessage.push('Usage: ', command.config.usage.map(usage => '`' + usage + '`').join(', '), '\n');
 
 			await message.author.send(helpMessage.join('')).catch(err => {

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,112 +1,112 @@
 const prefix = require('../config.json').prefix;
 
 module.exports.execute = async (client, message, args) => {
-    let commands = client.commands;
-    let commandNames = [];
+	let commands = client.commands;
+	let commandNames = [];
 
-    if (!args || args.length === 0) {
-        let helpMessage = ['__**List of available commands:**__\n\n'];
-        commands.forEach(command => {
-            helpMessage.push(
-                `**${command.config.name}** - ${command.config.description}\n`,
-            );
-        });
+	if (!args || args.length === 0) {
+		let helpMessage = ['__**List of available commands:**__\n\n'];
+		commands.forEach(command => {
+			helpMessage.push(
+				`**${command.config.name}** - ${command.config.description}\n`,
+			);
+		});
 
-        message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with the command list.')).catch(err => {
-            console.error(err);
-        });
-    } else if (args.length === 1) {
-        let command = commands.find(command => command.config.name === args[0].toLowerCase()
+		message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with the command list.')).catch(err => {
+			console.error(err);
+		});
+	} else if (args.length === 1) {
+		let command = commands.find(command => command.config.name === args[0].toLowerCase()
             || command.config.aliases.find(alias => alias === args[0].toLowerCase()));
 
-        if (command) {
-            let helpMessage = [`__**Help for the ${command.config.name} command:**__\n\n`];
-            helpMessage.push(command.config.description, '\n\n');
-            helpMessage.push('Aliasses: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
-            helpMessage.push('Usage: ', command.config.usage.map(usage => '`' + usage + '`').join(', '), '\n');
+		if (command) {
+			let helpMessage = [`__**Help for the ${command.config.name} command:**__\n\n`];
+			helpMessage.push(command.config.description, '\n\n');
+			helpMessage.push('Aliasses: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
+			helpMessage.push('Usage: ', command.config.usage.map(usage => '`' + usage + '`').join(', '), '\n');
 
-            message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with command information for that command.')).catch(err => {
-                console.error(err);
-            });
-        } else {
-            commands.forEach(command => {
-                commandNames.push(command.config.name);
-                command.config.aliases.forEach(alias => commandNames.push(alias));
-            });
-            didYouMean(commandNames, args[0].toLowerCase(), message);
-        }
-    }
-}
+			message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with command information for that command.')).catch(err => {
+				console.error(err);
+			});
+		} else {
+			commands.forEach(command => {
+				commandNames.push(command.config.name);
+				command.config.aliases.forEach(alias => commandNames.push(alias));
+			});
+			didYouMean(commandNames, args[0].toLowerCase(), message);
+		}
+	}
+};
 
 
 function didYouMean(commands, search, message) {
-    if (!commands.includes(search)) {
-        let score = [];
-        let lev = 1000;
-        let str = [];
-        for (let command of commands) {
-            if (levenshtein(search, command) <= lev) {
-                lev = levenshtein(search, command);
-                str.push(command);
-            }
-        }
-        if (str.length > 1) {
-            let arr = []
-            for (let string of str) {
-                arr.push(string.split(""))
-            }
-            for (let i = 0; i < arr.length; i++) {
-                score[i] = 0;
-                for (let j = 0; j < arr[i].length; j++) {
-                    if (search.split("")[j] === arr[i][j]) {
-                        score[i]++;
-                    }
-                }
-            }
-            return message.channel.send(`Did you mean \`${prefix}help ${str[score.indexOf(Math.max(...score))]}\`?`).catch(err => console.log(err));
+	if (!commands.includes(search)) {
+		let score = [];
+		let lev = 1000;
+		let str = [];
+		for (let command of commands) {
+			if (levenshtein(search, command) <= lev) {
+				lev = levenshtein(search, command);
+				str.push(command);
+			}
+		}
+		if (str.length > 1) {
+			let arr = [];
+			for (let string of str) {
+				arr.push(string.split(''));
+			}
+			for (let i = 0; i < arr.length; i++) {
+				score[i] = 0;
+				for (let j = 0; j < arr[i].length; j++) {
+					if (search.split('')[j] === arr[i][j]) {
+						score[i]++;
+					}
+				}
+			}
+			return message.channel.send(`Did you mean \`${prefix}help ${str[score.indexOf(Math.max(...score))]}\`?`).catch(err => console.log(err));
 
-        } else {
-            return message.channel.send(`Did you mean \`${prefix}help ${str[0]}\`?`).catch(err => console.log(err));
-        }
-    }
+		} else {
+			return message.channel.send(`Did you mean \`${prefix}help ${str[0]}\`?`).catch(err => console.log(err));
+		}
+	}
 }
 
 function levenshtein(searchTerm, commandName) {
-    if (searchTerm.length === 0) return commandName.length
-    if (commandName.length === 0) return searchTerm.length
-    let tmp, i, j, previous, val, row
-    if (searchTerm.length > commandName.length) {
-        tmp = searchTerm
-        searchTerm = commandName
-        commandName = tmp
-    }
+	if (searchTerm.length === 0) return commandName.length;
+	if (commandName.length === 0) return searchTerm.length;
+	let tmp, i, j, previous, val, row;
+	if (searchTerm.length > commandName.length) {
+		tmp = searchTerm;
+		searchTerm = commandName;
+		commandName = tmp;
+	}
 
-    row = Array(searchTerm.length + 1)
-    for (i = 0; i <= searchTerm.length; i++) {
-        row[i] = i
-    }
+	row = Array(searchTerm.length + 1);
+	for (i = 0; i <= searchTerm.length; i++) {
+		row[i] = i;
+	}
 
-    for (i = 1; i <= commandName.length; i++) {
-        previous = i
-        for (j = 1; j <= searchTerm.length; j++) {
-            if (commandName[i - 1] === searchTerm[j - 1]) {
-                val = row[j - 1]
-            } else {
-                val = Math.min(row[j - 1] + 1,
-                    Math.min(previous + 1,
-                        row[j] + 1))
-            }
-            row[j - 1] = previous
-            previous = val
-        }
-        row[searchTerm.length] = previous
-    }
-    return row[searchTerm.length]
+	for (i = 1; i <= commandName.length; i++) {
+		previous = i;
+		for (j = 1; j <= searchTerm.length; j++) {
+			if (commandName[i - 1] === searchTerm[j - 1]) {
+				val = row[j - 1];
+			} else {
+				val = Math.min(row[j - 1] + 1,
+					Math.min(previous + 1,
+						row[j] + 1));
+			}
+			row[j - 1] = previous;
+			previous = val;
+		}
+		row[searchTerm.length] = previous;
+	}
+	return row[searchTerm.length];
 }
 
 module.exports.config = {
-    name: 'help',
-    aliases: ['help'],
-    description: 'I will send you this message, or the usage of a specific command.',
-    usage: [`help`, `help command`],
-}
+	name: 'help',
+	aliases: ['help'],
+	description: 'I will send you this message, or the usage of a specific command.',
+	usage: ['help', 'help command'],
+};

--- a/commands/help.js
+++ b/commands/help.js
@@ -12,7 +12,10 @@ module.exports.execute = async (client, message, args) => {
 			);
 		});
 
-		message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with the command list.')).catch(err => {
+		message.author.send(helpMessage.join('')).catch(err => {
+			console.error(err);
+		});
+		message.reply('I have sent you a private message with the command list.').catch(err => {
 			console.error(err);
 		});
 	} else if (args.length === 1) {
@@ -25,7 +28,10 @@ module.exports.execute = async (client, message, args) => {
 			helpMessage.push('Aliasses: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
 			helpMessage.push('Usage: ', command.config.usage.map(usage => '`' + usage + '`').join(', '), '\n');
 
-			message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with command information for that command.')).catch(err => {
+			message.author.send(helpMessage.join('')).catch(err => {
+				console.error(err);
+			});
+			message.reply('I have sent you a private message with command information for that command.').catch(err => {
 				console.error(err);
 			});
 		} else {

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,6 +1,7 @@
-const prefix = require('../config.json').prefix;
-
+const prefix = (require('../config.json')) ? require('../config.json').prefix : '!';
 module.exports.execute = async (client, message, args) => {
+
+
 	let commands = client.commands;
 	let commandNames = [];
 
@@ -12,10 +13,10 @@ module.exports.execute = async (client, message, args) => {
 			);
 		});
 
-		message.author.send(helpMessage.join('')).catch(err => {
+		await message.author.send(helpMessage.join('')).catch(err => {
 			console.error(err);
 		});
-		message.reply('I have sent you a private message with the command list.').catch(err => {
+		return await message.channel.send('I have sent you a private message with the command list.').catch(err => {
 			console.error(err);
 		});
 	} else if (args.length === 1) {
@@ -28,10 +29,10 @@ module.exports.execute = async (client, message, args) => {
 			helpMessage.push('Aliasses: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
 			helpMessage.push('Usage: ', command.config.usage.map(usage => '`' + usage + '`').join(', '), '\n');
 
-			message.author.send(helpMessage.join('')).catch(err => {
+			await message.author.send(helpMessage.join('')).catch(err => {
 				console.error(err);
 			});
-			message.reply('I have sent you a private message with command information for that command.').catch(err => {
+			return await message.channel.send('I have sent you a private message with command information for that command.').catch(err => {
 				console.error(err);
 			});
 		} else {
@@ -39,13 +40,13 @@ module.exports.execute = async (client, message, args) => {
 				commandNames.push(command.config.name);
 				command.config.aliases.forEach(alias => commandNames.push(alias));
 			});
-			didYouMean(commandNames, args[0].toLowerCase(), message);
+			return didYouMean(commandNames, args[0].toLowerCase(), message);
 		}
 	}
 };
 
 
-function didYouMean(commands, search, message) {
+async function didYouMean(commands, search, message) {
 	if (!commands.includes(search)) {
 		let score = [];
 		let lev = 1000;
@@ -69,10 +70,10 @@ function didYouMean(commands, search, message) {
 					}
 				}
 			}
-			return message.channel.send(`Did you mean \`${prefix}help ${str[score.indexOf(Math.max(...score))]}\`?`).catch(err => console.log(err));
+			return await message.channel.send(`Did you mean \`${prefix}help ${str[score.indexOf(Math.max(...score))]}\`?`).catch(err => console.log(err));
 
 		} else {
-			return message.channel.send(`Did you mean \`${prefix}help ${str[0]}\`?`).catch(err => console.log(err));
+			return await message.channel.send(`Did you mean \`${prefix}help ${str[0]}\`?`).catch(err => console.log(err));
 		}
 	}
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,28 +1,112 @@
 const prefix = require('../config.json').prefix;
 
 module.exports.execute = async (client, message, args) => {
+    let commands = client.commands;
+    let commandNames = [];
+
     if (!args || args.length === 0) {
         let helpMessage = ['__**List of available commands:**__\n\n'];
-        let commands = client.commands;
         commands.forEach(command => {
             helpMessage.push(
                 `**${command.config.name}** - ${command.config.description}\n`,
             );
         });
 
-        message.author.send(helpMessage.join('')).then((res, err) => {
-            if (err) {
-                console.error(err);
-                return;
-            }
-            message.reply('I have sent you a private message with the command list')
+        message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with the command list')).catch(err => {
+            console.error(err);
         });
+    } else if (args.length === 1) {
+        let command = commands.find(command => command.config.name === args[0].toLowerCase()
+            || command.config.aliases.find(alias => alias === args[0].toLowerCase()));
+
+        if (command) {
+            let helpMessage = [`__**Help for the ${command.config.name} command:**__\n\n`];
+            helpMessage.push(command.config.description, '\n\n');
+            helpMessage.push('Aliasses: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
+            helpMessage.push('Usage: ', command.config.usage.map(usage => '`' + usage + '`').join(', '), '\n');
+
+            message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with command information')).catch(err => {
+                console.error(err);
+            });
+        } else {
+            commands.forEach(command => {
+                commandNames.push(command.config.name);
+                command.config.aliases.forEach(alias => commandNames.push(alias));
+            });
+            didYouMean(commandNames, args[0].toLowerCase(), message);
+        }
     }
+}
+
+
+function didYouMean(commands, search, message) {
+    if (!commands.includes(search)) {
+        let score = [];
+        let lev = 1000;
+        let str = [];
+        for (let command of commands) {
+            if (levenshtein(search, command) <= lev) {
+                lev = levenshtein(search, command);
+                str.push(command);
+            }
+        }
+        if (str.length > 1) {
+            let arr = []
+            for (let string of str) {
+                arr.push(string.split(""))
+            }
+            for (let i = 0; i < arr.length; i++) {
+                score[i] = 0;
+                for (let j = 0; j < arr[i].length; j++) {
+                    if (search.split("")[j] === arr[i][j]) {
+                        score[i]++;
+                    }
+                }
+            }
+            return message.channel.send(`Did you mean \`${prefix}help ${str[score.indexOf(Math.max(...score))]}\``).catch(err => console.log(err));
+
+        } else {
+            return message.channel.send(`Did you mean \`${prefix}help ${str[0]}\``).catch(err => console.log(err));
+        }
+    }
+}
+
+function levenshtein(searchTerm, commandName) {
+    if (searchTerm.length === 0) return commandName.length
+    if (commandName.length === 0) return searchTerm.length
+    let tmp, i, j, previous, val, row
+    if (searchTerm.length > commandName.length) {
+        tmp = searchTerm
+        searchTerm = commandName
+        commandName = tmp
+    }
+
+    row = Array(searchTerm.length + 1)
+    for (i = 0; i <= searchTerm.length; i++) {
+        row[i] = i
+    }
+
+    for (i = 1; i <= commandName.length; i++) {
+        previous = i
+        for (j = 1; j <= searchTerm.length; j++) {
+            if (commandName[i - 1] === searchTerm[j - 1]) {
+                val = row[j - 1]
+            } else {
+                val = Math.min(row[j - 1] + 1,
+                    Math.min(previous + 1,
+                        row[j] + 1))
+            }
+            row[j - 1] = previous
+            previous = val
+        }
+        row[searchTerm.length] = previous
+    }
+    return row[searchTerm.length]
 }
 
 module.exports.config = {
     name: 'help',
     aliases: ['help'],
     description: 'I will send you this message, or the usage of a specific command.',
-    usage: [`help`, `help <command>`],
+    usage: [`help`, `help command`],
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -12,7 +12,7 @@ module.exports.execute = async (client, message, args) => {
             );
         });
 
-        message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with the command list')).catch(err => {
+        message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with the command list.')).catch(err => {
             console.error(err);
         });
     } else if (args.length === 1) {
@@ -25,7 +25,7 @@ module.exports.execute = async (client, message, args) => {
             helpMessage.push('Aliasses: ', command.config.aliases.map(alias => '`' + alias + '`').join(', '), '\n');
             helpMessage.push('Usage: ', command.config.usage.map(usage => '`' + usage + '`').join(', '), '\n');
 
-            message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with command information')).catch(err => {
+            message.author.send(helpMessage.join('')).then(res => message.reply('I have sent you a private message with command information for that command.')).catch(err => {
                 console.error(err);
             });
         } else {
@@ -63,10 +63,10 @@ function didYouMean(commands, search, message) {
                     }
                 }
             }
-            return message.channel.send(`Did you mean \`${prefix}help ${str[score.indexOf(Math.max(...score))]}\``).catch(err => console.log(err));
+            return message.channel.send(`Did you mean \`${prefix}help ${str[score.indexOf(Math.max(...score))]}\`?`).catch(err => console.log(err));
 
         } else {
-            return message.channel.send(`Did you mean \`${prefix}help ${str[0]}\``).catch(err => console.log(err));
+            return message.channel.send(`Did you mean \`${prefix}help ${str[0]}\`?`).catch(err => console.log(err));
         }
     }
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -2,15 +2,27 @@ const prefix = require('../config.json').prefix;
 
 module.exports.execute = async (client, message, args) => {
     if (!args || args.length === 0) {
-        
+        let helpMessage = ['__**List of available commands:**__\n\n'];
+        let commands = client.commands;
+        commands.forEach(command => {
+            helpMessage.push(
+                `**${command.config.name}** - ${command.config.description}\n`,
+            );
+        });
 
-        message.channel.send()
+        message.author.send(helpMessage.join('')).then((res, err) => {
+            if (err) {
+                console.error(err);
+                return;
+            }
+            message.reply('I have sent you a private message with the command list')
+        });
     }
 }
 
 module.exports.config = {
     name: 'help',
     aliases: ['help'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    description: 'I will send you this message, or the usage of a specific command.',
+    usage: [`help`, `help <command>`],
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,16 @@
+const prefix = require('../config.json').prefix;
+
+module.exports.execute = async (client, message, args) => {
+    if (!args || args.length === 0) {
+        
+
+        message.channel.send()
+    }
+}
+
+module.exports.config = {
+    name: 'help',
+    aliases: ['help'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
+}

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,4 +1,11 @@
-const prefix = (require('../config.json')) ? require('../config.json').prefix : '!';
+const fs = require('fs');
+let prefix;
+if (fs.existsSync('../config.json')) {
+	prefix = require('../config.json');
+} else {
+	prefix = '!';
+}
+
 module.exports.execute = async (client, message, args) => {
 
 

--- a/commands/help.test.js
+++ b/commands/help.test.js
@@ -1,12 +1,11 @@
-const prefix = require('../config.json').prefix;
 const help = require('./help.js');
 const messageStup = require('../stub/messageStub');
 
-test("Sends default help message when no argument is provided", async () => {
-    const messsage = new messageStup();
+test('Sends default help message when no argument is provided', async () => {
+	const messsage = new messageStup();
 
-    const responseMessage = help.execute(null, messsage, null);
+	const responseMessage = help.execute(null, messsage, null);
 
-    const expectedResponse = 'I have sent you a private message with the command list';
-    expect(responseMessage).toContain(expectedResponse);
+	const expectedResponse = 'I have sent you a private message with the command list';
+	expect(responseMessage).toContain(expectedResponse);
 });

--- a/commands/help.test.js
+++ b/commands/help.test.js
@@ -1,0 +1,12 @@
+const prefix = require('../config.json').prefix;
+const help = require('./help.js');
+const messageStup = require('../stub/messageStub');
+
+test("Sends default help message when no argument is provided", async () => {
+    const messsage = new messageStup();
+
+    const responseMessage = help.execute(null, messsage, null);
+
+    const expectedResponse = 'I have sent you a private message with the command list';
+    expect(responseMessage).toContain(expectedResponse);
+});

--- a/commands/help.test.js
+++ b/commands/help.test.js
@@ -1,11 +1,39 @@
+const Discord = require('discord.js');
 const help = require('./help.js');
 const messageStup = require('../stub/messageStub');
 
 test('Sends default help message when no argument is provided', async () => {
 	const messsage = new messageStup();
+	let client = new Discord.Client();
+	client.commands = new Discord.Collection();
+	['help', 'facebook','invite','coinflip'].forEach(name => client.commands.set(name, require(`./${name}`)));
 
-	const responseMessage = help.execute(null, messsage, null);
+	const responseMessage = await help.execute(client, messsage, []);
 
-	const expectedResponse = 'I have sent you a private message with the command list';
-	expect(responseMessage).toContain(expectedResponse);
+	const expectedResponse = 'I have sent you a private message with the command list.';
+	expect(responseMessage).toBe(expectedResponse);
+});
+
+test('Sends default help message when an argument is provided', async () => {
+	const messsage = new messageStup();
+	let client = new Discord.Client();
+	client.commands = new Discord.Collection();
+	['help', 'facebook','invite','coinflip'].forEach(name => client.commands.set(name, require(`./${name}`)));
+
+	const responseMessage = await help.execute(client, messsage, ['help']);
+
+	const expectedResponse = 'I have sent you a private message with command information for that command.';
+	expect(responseMessage).toBe(expectedResponse);
+});
+
+test('Sends name correction when an incorrect command is looked up', async () => {
+	const messsage = new messageStup();
+	let client = new Discord.Client();
+	client.commands = new Discord.Collection();
+	['help', 'facebook','invite','coinflip'].forEach(name => client.commands.set(name, require(`./${name}`)));
+
+	const responseMessage = await help.execute(client, messsage, ['yelp']);
+    
+	const expectedResponse = 'Did you mean `!help help`?';
+	expect(responseMessage).toBe(expectedResponse);
 });

--- a/commands/invite.js
+++ b/commands/invite.js
@@ -16,6 +16,6 @@ module.exports.execute = async (client, message, args) => {
 module.exports.config = {
 	name: 'invite',
 	aliases: ['invite', 'discord'],
-    description: 'Want to invite a friend to the server? This will get you the invite link.',
-    usage: ['invite','invite camelot', 'invite koai'],
+	description: 'Want to invite a friend to the server? This will get you the invite link.',
+	usage: ['invite','invite camelot', 'invite koai'],
 };

--- a/commands/invite.js
+++ b/commands/invite.js
@@ -16,4 +16,6 @@ module.exports.execute = async (client, message, args) => {
 module.exports.config = {
 	name: 'invite',
 	aliases: ['invite', 'discord'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/invite.js
+++ b/commands/invite.js
@@ -16,6 +16,6 @@ module.exports.execute = async (client, message, args) => {
 module.exports.config = {
 	name: 'invite',
 	aliases: ['invite', 'discord'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    description: 'Want to invite a friend to the server? This will get you the invite link.',
+    usage: ['invite','invite camelot', 'invite koai'],
 };

--- a/commands/newsletter.js
+++ b/commands/newsletter.js
@@ -12,6 +12,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'newsletter',
 	aliases: ['newsletter', 'news'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`],
+    description: 'Want to read our newsletter? This is the command for that.',
+    usage: [`newsletter`],
 };

--- a/commands/newsletter.js
+++ b/commands/newsletter.js
@@ -12,6 +12,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'newsletter',
 	aliases: ['newsletter', 'news'],
-    description: 'Want to read our newsletter? This is the command for that.',
-    usage: [`newsletter`],
+	description: 'Want to read our newsletter? This is the command for that.',
+	usage: ['newsletter'],
 };

--- a/commands/newsletter.js
+++ b/commands/newsletter.js
@@ -12,4 +12,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'newsletter',
 	aliases: ['newsletter', 'news'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`],
 };

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -7,4 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'raid',
 	aliases: ['raid'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`],
 };

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -7,6 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'raid',
 	aliases: ['raid'],
-    description: 'RAAAAAAAAAID!',
-    usage: [`raid`],
+	description: 'RAAAAAAAAAID!',
+	usage: ['raid'],
 };

--- a/commands/raid.js
+++ b/commands/raid.js
@@ -7,6 +7,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'raid',
 	aliases: ['raid'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`],
+    description: 'RAAAAAAAAAID!',
+    usage: [`raid`],
 };

--- a/commands/website.js
+++ b/commands/website.js
@@ -5,6 +5,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'website',
 	aliases: ['website', 'koa'],
-    description: 'I will fetch you the link for our website.',
-    usage: [`website`]
+	description: 'I will fetch you the link for our website.',
+	usage: ['website']
 };

--- a/commands/website.js
+++ b/commands/website.js
@@ -4,5 +4,7 @@ module.exports.execute = async (client, message) => {
 
 module.exports.config = {
 	name: 'website',
-	aliases: ['website', 'koa']
+	aliases: ['website', 'koa'],
+    description: 'TEMPLATE',
+    usage: [`${prefix}TEMPLATE`]
 };

--- a/commands/website.js
+++ b/commands/website.js
@@ -5,6 +5,6 @@ module.exports.execute = async (client, message) => {
 module.exports.config = {
 	name: 'website',
 	aliases: ['website', 'koa'],
-    description: 'TEMPLATE',
-    usage: [`${prefix}TEMPLATE`]
+    description: 'I will fetch you the link for our website.',
+    usage: [`website`]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2092,7 +2092,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2507,7 +2508,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2563,6 +2565,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2606,12 +2609,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/stub/messageStub.js
+++ b/stub/messageStub.js
@@ -3,5 +3,8 @@ module.exports = class messageStub {
 		this.channel = {
 			send: async function (message) { return Promise.resolve(message); }
 		};
+		this.author = {
+			send: async function (message) { return Promise.resolve(message); }
+		};
 	}
 };


### PR DESCRIPTION
This pull request will add a help command to the bot. This will implement the feature resqeted in-, and close #32.

The command allows the user to list every command or get the specific usage of a specific command. The help messages are sent as private messages, to minimise clutter in the chat
![helplist](https://x0.at/BlY.png)
![help for command](https://x0.at/r1c.png)

Furthermore, if a command is misspelled, when asking for a specific command, the bot will suggest the most plausible match of the misspelled command, using Levenshtein Distance.
![suggestion of misspelled command](https://x0.at/naK.png)