### PR TITLE
Snapshots moderation

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -14,7 +14,9 @@
   "channels": {
     "citadel": "000",
     "cotw": "000",
-    "tos": "000"
+    "tos": "000",
+    "snapshots": "000",
+    "moderation": "000"
   },
   "emotes": {
     "acceptTOS": "✅"

--- a/eventActions/snapshotActions.js
+++ b/eventActions/snapshotActions.js
@@ -18,8 +18,8 @@ class snapshotActions {
 				.setDescription(`An unapproved message was sent in <#${config.channels.snapshots}>`)
 				.addField('User', message.author, true);
 
-            // Split message into multiple, in case takes up more space than
-            // what discordjs allows for a field.
+			// Split message into multiple, in case takes up more space than
+			// what discordjs allows for a field.
 			const messageCunks = message.content.match(/[\s\S]{1,1024}/g);
 
 			for (let chunk of messageCunks) {

--- a/eventActions/snapshotActions.js
+++ b/eventActions/snapshotActions.js
@@ -20,9 +20,9 @@ class snapshotActions {
 
 			// Split message into multiple, in case takes up more space than
 			// what discordjs allows for a field.
-			const messageCunks = message.content.match(/[\s\S]{1,1024}/g);
+			const messageChunks = message.content.match(/[\s\S]{1,1024}/g);
 
-			for (let chunk of messageCunks) {
+			for (let chunk of messageChunks) {
 				embedMessage.addField('Message', chunk);
 			}
 			// Send message to moderation log

--- a/eventActions/snapshotActions.js
+++ b/eventActions/snapshotActions.js
@@ -1,0 +1,18 @@
+const config = require('../config.json');
+
+class snapshotActions {
+    static userPostsImage(client, message) {
+        if (message.channel.id === config.channels.snapshots
+            && message.attachments.size === 0) {
+
+            // Delete message
+
+            // Send warning to author
+
+            // Send message to moderation log
+        }
+    }
+
+}
+
+module.exports = snapshotActions;

--- a/eventActions/snapshotActions.js
+++ b/eventActions/snapshotActions.js
@@ -1,17 +1,27 @@
 const config = require('../config.json');
+const Discord = require('discord.js');
 
 class snapshotActions {
-    static userPostsImage(client, message) {
-        if (message.channel.id === config.channels.snapshots
+	static async userPostsImage(client, message) {
+		if (message.channel.id === config.channels.snapshots
             && message.attachments.size === 0) {
 
-            // Delete message
+			// Delete message
+			await message.delete();
 
-            // Send warning to author
+			// Send warning to author
+			await message.author.send(`Hey! I noticed you sent a message in <#${config.channels.snapshots}> that wasn't a picture. To help maintain the integrity of the channel, the staff team has made the decision to only allow pictures, captions and reactions there. As a result of this, your message has been removed. Thanks for understanding! 😄`);
 
-            // Send message to moderation log
-        }
-    }
+			const embedMessage = new Discord.RichEmbed()
+				.setColor('#ff0000')
+				.setTitle('🚩 Warning: Snapshots message 🚩')
+				.setDescription(`An unapproved message was sent in <#${config.channels.snapshots}>`)
+				.addField('User', message.author, true)
+				.addField('Message', message.content);
+			// Send message to moderation log
+			client.channels.get(config.channels.moderation).send(embedMessage);
+		}
+	}
 
 }
 

--- a/eventActions/snapshotActions.js
+++ b/eventActions/snapshotActions.js
@@ -16,8 +16,15 @@ class snapshotActions {
 				.setColor('#ff0000')
 				.setTitle('🚩 Warning: Snapshots message 🚩')
 				.setDescription(`An unapproved message was sent in <#${config.channels.snapshots}>`)
-				.addField('User', message.author, true)
-				.addField('Message', message.content);
+				.addField('User', message.author, true);
+
+            // Split message into multiple, in case takes up more space than
+            // what discordjs allows for a field.
+			const messageCunks = message.content.match(/[\s\S]{1,1024}/g);
+
+			for (let chunk of messageCunks) {
+				embedMessage.addField('Message', chunk);
+			}
 			// Send message to moderation log
 			client.channels.get(config.channels.moderation).send(embedMessage);
 		}

--- a/events/message.js
+++ b/events/message.js
@@ -1,5 +1,6 @@
 const config = require('../config.json');
 const cotwActions = require('../eventActions/cotwActions');
+const snapshotActions = require('../eventActions/snapshotActions');
 
 module.exports = async (client, message) => {
 	if (!message.guild || message.author.bot) return;
@@ -16,6 +17,8 @@ module.exports = async (client, message) => {
 		if (commandfile) commandfile.execute(client, message, args); // Execute found command
 	}
 
+	// Handle snapshots
+	snapshotActions.userPostsImage(client, message);
 	// Handle COTW case
 	cotwActions.updateCotw(client, message);
 };


### PR DESCRIPTION
Fixes #35 

When a message in snapshots is sent without an attachment:
![image](https://user-images.githubusercontent.com/21969475/67070499-7dc9dd00-f180-11e9-8578-1ba0ceea60fe.png)

It will be deleted
![image](https://user-images.githubusercontent.com/21969475/67070521-87534500-f180-11e9-9463-c9932bbe7871.png)

Then the user will get a warning in DMs
![image](https://user-images.githubusercontent.com/21969475/67070533-90dcad00-f180-11e9-83b4-bffd81bbfe89.png)

And finally, a message is sent to the moderation channel:
![image](https://user-images.githubusercontent.com/21969475/67070892-85d64c80-f181-11e9-97d9-8b3e5ffd245b.png)




Since Discord only allows a field in an embedded message to be 1024 characters, I had to choose between cutting off the message or splitting it into multiple fields.
I went with the latter, even though it seems a bit odd to have the new message field in the middle of it.