### PR TITLE
change message to lowercase before profanity check

### DIFF
--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -18,7 +18,8 @@ class profanityActions {
 			'tranny'
 		];
 
-		const containedProfanity = profanityList.some(substring => message.content.includes(substring));
+		const lowerCaseMessage = message.content.toLowerCase();
+		const containedProfanity = profanityList.some(substring => lowerCaseMessage.includes(substring));
 
 		if (containedProfanity) {
 			const embedMessage = new Discord.RichEmbed()


### PR DESCRIPTION
This fixes #71 by using a lowercase version of the message to check for profanity.