### PR TITLE
Change check for which emote.

### DIFF
--- a/eventActions/accountabilityActions.js
+++ b/eventActions/accountabilityActions.js
@@ -159,7 +159,7 @@ class accountabilityActions {
 		});
 
 		// Check for emotes
-		if(message.content.toLowerCase().includes(':yes:') || message.content.toLowerCase().includes(':yes2:') || message.content.toLowerCase().includes(':white_check_mark:')){
+		if(message.content.toLowerCase().includes(':check:') || message.content.toLowerCase().includes(':white_check_mark:')){
 			// Pull a random reaction from the common emotes for and add to post (personally I like the separation of variables, let me know if that's not preferred style)
 			const rand = Math.floor(Math.random() * length);
 			const selectedEmote = random_emotes[rand];


### PR DESCRIPTION
Recently, custom emote `:yes2:` was changed to `:check:`, and the custom emote `:yes:` was removed entirely.

This has been updated in the code. The reason why this is hardcoded is because the emote is not always processed into an emote, or so my last testing reflected. For now, I wanted to get a quick fix up.

**Unless Horace is being updated tomorrow, _please do not merge this PR_.** I would like to create an array in the config that stores these emotes _as strings_ (versus IDs) in my free time tomorrow when I work on the highlight feature in case emotes get updated in the future