### PR TITLE
Added profanity highlighting to Horace

### DIFF
--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -2,11 +2,38 @@ const config = require('../config.json');
 const Discord = require('discord.js');
 
 class profanityActions {
+
+
+
 	static async checkForProfanity(client, message) {
 		const profanityList = config.modules.profanityArray;
 
 		const lowerCaseMessage = message.content.toLowerCase();
-		const containedProfanity = profanityList.some(substring => lowerCaseMessage.includes(substring));
+		let profaneWord;
+		const containedProfanity = profanityList.some(substring => {
+			profaneWord = substring;
+			return lowerCaseMessage.includes(substring);
+		});
+		const getSection = (message, word) => {
+			let start = message.content.indexOf(word) - 10;
+			let end = message.content.indexOf(word) + word.length + 10;
+			// Add padding to the mare
+			return message.content.substring(start, end);
+		};
+
+		const getMarker = (word, spacePadding) => {
+			let marker = '';
+			for (let i = 0; i < spacePadding; i++) {
+				marker += ' ';
+			}
+			for (let i = 0; i < word.length; i++) {
+				marker += '‾';
+			}
+			return marker;
+		};
+		const collectPlacement = (word, marker) => {
+			return'```\n'+word+'\n'+marker+'\n'+'```';
+		};
 
 		if (containedProfanity) {
 			const embedMessage = new Discord.RichEmbed()
@@ -24,11 +51,28 @@ class profanityActions {
 			for (let chunk of messageChunks) {
 				embedMessage.addField('Message', chunk);
 			}
+			let section = '';
+			if (message.content.length > 20) {
+				let messagePart = '';
+				if (message.content.indexOf(profaneWord) > 10) messagePart += '...';
+				messagePart += getSection(message, profaneWord);
+				if (message.content.substring(message.content.indexOf(profaneWord) + profaneWord.length).length > 10) messagePart += '...';
+				let marker = getMarker(profaneWord, messagePart.indexOf(profaneWord));
+				section += collectPlacement(messagePart, marker);
+				
+			} else {
+				let marker = getMarker(profaneWord, message.content.indexOf(profaneWord));
+				section = collectPlacement(message.content, marker);
+			}
+			embedMessage.addField('Here', section, false);
 
 			// Send message to moderation log
 			client.channels.get(config.channels.moderation).send(embedMessage);
 		}
+
 	}
+
+
 
 }
 


### PR DESCRIPTION
This pull request will implement a highlighting feature for the profanity embed.
The embeds will now have an extra field marking the first occurrence of a word, listed as profane.
It looks as following:
![image](https://user-images.githubusercontent.com/35431127/77554976-062e7580-6eb7-11ea-9b79-7af4f7964a47.png)

The marker has a dynamic length, and should adjust according to the length of the word, as well as the placement of it
