### PR TITLE
Fixed invalid example config

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -25,9 +25,8 @@
     "accountability": "000",
     "chooseroles": "000",
     "gratitude": "000",
-    "staffaccountability": "000"
+    "staffaccountability": "000",
     "commandcenter": "000"
-  },
   },
   "emotes": {
     "acceptTOS": "✅",
@@ -61,6 +60,6 @@
   "forceStrictGreetings": false,
   "strict_morning_regex": "mo*rning (koa[^a-z]*|knights[^a-z]*|friends[^a-z]*|everyone[^a-z]*)$",
   "strict_night_regex": "ni*ght (koa[^a-z]*|knights[^a-z]*|friends[^a-z]*|everyone[^a-z]*)$",
-  "normal_morning_regex": "g+o{2,}d+\s*m+o+r+n+i+n+g+",
-  "normal_night_regex: "g+o{2,}d+\s*n+i+g+h+t+"
+  "normal_morning_regex": "g+o{2,}d+\\s*m+o+r+n+i+n+g+",
+  "normal_night_regex": "g+o{2,}d+\\s*n+i+g+h+t+"
 }


### PR DESCRIPTION
This PR fixes the invalid example config currently found in the develop branch, which gave me some trouble running the bot (especially because of the regex). There are missing commas and invalid escapes.

GitHub seems to be unable to render this diff so I recommend using a third-party site like https://diffchecker.com.