### PR TITLE
* handle error when no bannedWords are found in DB

### DIFF
--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -3,11 +3,14 @@ const Discord = require('discord.js');
 const db = require('quick.db');
 class profanityActions {
 
-
-
 	static async checkForProfanity(client, message) {
 		const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
-		if (bannedWords.some((word) => message.content.includes(word))) {
+		
+		if (!bannedWords) {
+			console.log("Error: No banned words found in database.");
+			return;
+		}
+		else if (bannedWords.some((word) => message.content.includes(word))) {
 			const embedMessage = new Discord.MessageEmbed()
 				.setColor('#ff0000')
 				.setTitle('🚩 Warning: Profanity detected 🚩')


### PR DESCRIPTION
When `bannedWords` table is empty or not set, the function will throw an error because we were not checking for null. I've added a null-check which displays the problem in the console and immediately returns from the function.

Tested locally and it works as expected. The error doesn't appear and we get the "No banned words found in database" message instead.