### PR TITLE
Check that moderation channelID is valid before attempting profanity check

### DIFF
--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -3,11 +3,14 @@ const Discord = require('discord.js');
 const db = require('quick.db');
 class profanityActions {
 
-
-
 	static async checkForProfanity(client, message) {
 		const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
-		if (bannedWords.some((word) => message.content.includes(word))) {
+		
+		if (!bannedWords) {
+			console.log("Error: No banned words found in database.");
+			return;
+		}
+		else if (bannedWords.some((word) => message.content.includes(word))) {
 			const embedMessage = new Discord.MessageEmbed()
 				.setColor('#ff0000')
 				.setTitle('🚩 Warning: Profanity detected 🚩')

--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -1,37 +1,37 @@
-const config = require('../config.json');
 const Discord = require('discord.js');
 const db = require('quick.db');
-class profanityActions {
+const config = require('../config.json');
 
-	static async checkForProfanity(client, message) {
-		const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
-		
-		// check that moderation channelID is valid before attempting profanity check
-		if (client.channels.cache.get(config.channels.moderation) === undefined) {
-			console.log("Error! Moderation Channel ID in Config in likely invalid. Please verify!");
-			return;
-		}
-		else if (!bannedWords) { // ensure bannedWords is populated
-			console.log("Error: No banned words found in database.");
-			return;
-		}
-		else if (bannedWords.some((word) => message.content.includes(word))) {
-			const embedMessage = new Discord.MessageEmbed()
-				.setColor('#ff0000')
-				.setTitle('🚩 Warning: Profanity detected 🚩')
-				.setDescription(`Profanity detected in ${message.channel}`)
-				.addField('User', message.author, true)
-				.addField('Link', `[Go to message](${message.url})`, true)
-				.addField('Message', `**${message.content}**`, true)
-				.setFooter(
-					message.author.username + '#' + message.author.discriminator,
-					message.author.avatarURL
-				);
-			return client.channels.cache
-				.get(config.channels.moderation)
-				.send(embedMessage);
-		}
-	}
+class profanityActions {
+  static async checkForProfanity(client, message) {
+    const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
+
+    // check that moderation channelID is valid before attempting profanity check
+    if (client.channels.cache.get(config.channels.moderation) === undefined) {
+      console.log('Error! Moderation Channel ID in Config in likely invalid. Please verify!');
+    }
+    else if (!bannedWords) { // ensure bannedWords is populated
+      console.log('Error: No banned words found in database.');
+    }
+
+    if (bannedWords.some((word) => message.content.includes(word))) {
+      const embedMessage = new Discord.MessageEmbed()
+        .setColor('#ff0000')
+        .setTitle('🚩 Warning: Profanity detected 🚩')
+        .setDescription(`Profanity detected in ${message.channel}`)
+        .addField('User', message.author, true)
+        .addField('Link', `[Go to message](${message.url})`, true)
+        .addField('Message', `**${message.content}**`, true)
+        .setFooter(
+          `${message.author.username}#${message.author.discriminator}`,
+          message.author.avatarURL,
+        );
+      return client.channels.cache
+        .get(config.channels.moderation)
+        .send(embedMessage);
+    }
+    return null;
+  }
 }
 
 module.exports = profanityActions;

--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -6,7 +6,12 @@ class profanityActions {
 	static async checkForProfanity(client, message) {
 		const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
 		
-		if (!bannedWords) {
+		// check that moderation channelID is valid before attempting profanity check
+		if (client.channels.cache.get(config.channels.moderation) === undefined) {
+			console.log("Error! Moderation Channel ID in Config in likely invalid. Please verify!");
+			return;
+		}
+		else if (!bannedWords) { // ensure bannedWords is populated
 			console.log("Error: No banned words found in database.");
 			return;
 		}


### PR DESCRIPTION
If there is a configuration error is present it's not logged to console. 

This validates that channel ID for `moderation` is valid before any attempt to check for profanities. If the ID is invalid it will be logged to console and it will be easy to detect.