### PR TITLE
Bring profanityActions DB into Sequelize #211

### DIFF
--- a/commands/afk.js
+++ b/commands/afk.js
@@ -7,64 +7,64 @@ module.exports.execute = async (client, message, args) => {
 	const afkMessage = args.length > 0 ? args.join(' ') : 'They didn\'t tell us where they went...';
 
 	Afks.sync().then(() =>
-	  Afks.findAll({
-	    where: {
-	      user: sender.id,
-	    },
-	  }).then(findresult => {
-	    if (findresult.length == 0) {
-	      Afks.create({
-		message: afkMessage,
-		cooldown: Date.now(),
-		user: sender.id
-	      }).then(() => {
-		sender.send('I have marked you as AFK. Safe travels!').then(msg => msg.delete(5000).catch());
-	      }).catch(err => {
-		if (err.name == 'SequelizeUniqueConstraintError') {
-		  Afks.destroy({
-		      where: {
-			user: sender.id,
-		      },
-		    }).then((result) => {
-		      // User successfully removed from table
-		      if (result == 1) {
-			return message.channel
-		    .send(
-		      `Welcome back, ${
-			message.member.nickname
-			  ? message.member.nickname
-			  : message.author.username
-		      }!`
-		    )
-		    .then((delmessage) => delmessage.delete({ timeout: 5000 }))
-		    .catch('Error sending message.');
-		      }
-		    });
-		}
-		console.error('Afk sequelize error: ', err);
-	      })
-	    } else {
-	      Afks.destroy({
-		where: {
-		  user: sender.id,
-		},
-	      }).then((result) => {
-		// User successfully removed from table
-		if (result == 1) {
-		  return message.channel
-		    .send(
-		      `Welcome back, ${
-			message.member.nickname
-			  ? message.member.nickname
-			  : message.author.username
-		      }!`
-		    )
-		    .then((delmessage) => delmessage.delete({ timeout: 5000 }))
-		    .catch('Error sending message.');
-		}
-	      });
-	    }
-	  })
+		Afks.findAll({
+			where: {
+				user: sender.id,
+			},
+		}).then(findresult => {
+			if (findresult.length == 0) {
+				Afks.create({
+					message: afkMessage,
+					cooldown: Date.now(),
+					user: sender.id
+				}).then(() => {
+					sender.send('I have marked you as AFK. Safe travels!').then(msg => msg.delete(5000).catch());
+				}).catch(err => {
+					if (err.name == 'SequelizeUniqueConstraintError') {
+						Afks.destroy({
+							where: {
+								user: sender.id,
+							},
+						}).then((result) => {
+							// User successfully removed from table
+							if (result == 1) {
+								return message.channel
+									.send(
+										`Welcome back, ${
+											message.member.nickname
+												? message.member.nickname
+												: message.author.username
+										}!`
+									)
+									.then((delmessage) => delmessage.delete({ timeout: 5000 }))
+									.catch('Error sending message.');
+							}
+						});
+					}
+					console.error('Afk sequelize error: ', err);
+				});
+			} else {
+				Afks.destroy({
+					where: {
+						user: sender.id,
+					},
+				}).then((result) => {
+					// User successfully removed from table
+					if (result == 1) {
+						return message.channel
+							.send(
+								`Welcome back, ${
+									message.member.nickname
+										? message.member.nickname
+										: message.author.username
+								}!`
+							)
+							.then((delmessage) => delmessage.delete({ timeout: 5000 }))
+							.catch('Error sending message.');
+					}
+				});
+			}
+		})
 	);
 };
 

--- a/commands/banword.js
+++ b/commands/banword.js
@@ -1,22 +1,25 @@
-const db = require('quick.db');
+const BanWordUtils = require('../utils/banwordUtils.js');
 const config = require('../config.json');
 
 module.exports.execute = async (client, message, args) => {
-	if(message.member.roles.has(config.roles.guardian) | message.member.roles.has(config.roles.helper)) {
-		if(!args[0]) {
-			return message.channel.send('Please enter a word to ban!');
+	if (message.member.roles.cache.has(config.roles.guardian)
+  || message.member.roles.cache.has(config.roles.helper)) {
+		if (!args[0]) {
+			message.channel.send('Please enter a word to ban!');
+			return;
 		}
-		db.push(`bannedWords-${message.guild.id}`, args[0]);
-		return message.channel.send(`Success! Added ${args[0]} to the blocked word list!`);
+
+		const returnMessage = await BanWordUtils.addWordToBannedWordTable(args[0], message.member.id);
+		message.channel.send(returnMessage);
+		return;
 	}
-	else {
-		message.reply('Only moderators can run this command!');
-	}
+
+	message.reply('Only moderators can run this command!');
 };
 
 module.exports.config = {
 	name: 'banword',
 	aliases: ['blockword'],
 	description: 'Bans a specific word.',
-	usage: ['banword word']
+	usage: ['banword word'],
 };

--- a/commands/banword.js
+++ b/commands/banword.js
@@ -9,7 +9,7 @@ module.exports.execute = async (client, message, args) => {
 			return;
 		}
 
-		const returnMessage = await BanWordUtils.addWordToBannedWordTable(args[0], message.member.id);
+		const returnMessage = await BanWordUtils.addWordToBannedWordTable(args[0].toLowerCase(), message.member.id);
 		message.channel.send(returnMessage);
 		return;
 	}

--- a/commands/listbanword.js
+++ b/commands/listbanword.js
@@ -1,0 +1,28 @@
+const Discord = require('discord.js');
+const BanWordUtils = require('../utils/banwordUtils.js');
+
+module.exports.execute = async (client, message) => {
+	const bannedWords = await BanWordUtils.getBannedWordsAndAuthors();
+	const embedMessage = new Discord.MessageEmbed()
+		.setColor('#ffff00')
+		.setTitle('🚩Banned Words 🚩')
+		.setDescription('Here is the list of the banned words: ');	
+	
+	for (const element of bannedWords) { // eslint-disable-line
+		const user = await client.users.cache.get(element.userID);
+		const username = user.username;
+		embedMessage.addField(`${element.word}`,`added by ${username}`);
+	}
+
+	embedMessage.setFooter('To ban more words use the !banword <word> command and to unban words use the !unbanword <word> command.');
+
+	const sourceMember = await message.member;
+	return sourceMember.send(embedMessage);
+};
+
+module.exports.config = {
+	name: 'listbanword',
+	aliases: ['listblockword'],
+	description: 'Lists banned words and their authors.',
+	usage: ['listbanword'],
+};

--- a/commands/unbanword.js
+++ b/commands/unbanword.js
@@ -1,26 +1,23 @@
-const db = require('quick.db');
 const config = require('../config.json');
+const BanWordUtils = require('../utils/banwordUtils.js');
+
 module.exports.execute = async (client, message, args) => {
-	if(message.member.roles.has(config.roles.guardian) | message.member.roles.has(config.roles.helper)) {
-		if(!args[0]) {
+	if (message.member.roles.cache.has(config.roles.guardian)
+  || message.member.roles.cache.has(config.roles.helper)) {
+		if (!args[0]) {
 			return message.channel.send('Please enter a word to unban!');
 		}
-		const currentBannedWords = await db.get(`bannedWords-${message.guild.id}`);
-		if(!currentBannedWords.some(word => word == args[0]) ) {
-			return message.channel.send('That word isn\'t currently banned!');
-		}
-		const newBannedWords = currentBannedWords.filter(e => e !== args[0]);
-		db.set(`bannedWords-${message.guild.id}`, newBannedWords);
-		return message.channel.send(`Success! Unbanned ${args[0]} from the list!`);	
+
+		const removalQueryResult = await BanWordUtils.deleteWord(args[0]);
+		return message.channel.send(removalQueryResult);
 	}
-	else {
-		message.reply('Only moderators can run this command!');
-	}
+
+	return message.reply('Only moderators can run this command!');
 };
 
 module.exports.config = {
 	name: 'unbanword',
 	aliases: ['unblockword'],
 	description: 'Unbans a specific word.',
-	usage: ['unbanword word']
+	usage: ['unbanword word'],
 };

--- a/commands/unbanword.js
+++ b/commands/unbanword.js
@@ -8,7 +8,7 @@ module.exports.execute = async (client, message, args) => {
 			return message.channel.send('Please enter a word to unban!');
 		}
 
-		const removalQueryResult = await BanWordUtils.deleteWord(args[0]);
+		const removalQueryResult = await BanWordUtils.deleteWord(args[0].toLowerCase());
 		return message.channel.send(removalQueryResult);
 	}
 

--- a/databaseFiles/bannedWordTable.js
+++ b/databaseFiles/bannedWordTable.js
@@ -1,0 +1,16 @@
+const Sequelize = require('sequelize');
+const connect = require('./connect.js');
+
+const { sequelize } = connect;
+
+module.exports = sequelize.define('bannedWord', {
+	word: {
+		type: Sequelize.STRING,
+		allowNull: false,
+		unique: true,
+	},
+	userID: {
+		type: Sequelize.STRING,
+		allowNull: false,
+	},
+});

--- a/eventActions/afkMessageCheckAction.js
+++ b/eventActions/afkMessageCheckAction.js
@@ -33,6 +33,7 @@ class afkMessageCheckAction {
 				}
 			}
 		};
+		
 		const noLongerAFKMessage = new Discord.MessageEmbed()
 			.setTitle(`You are currently AFK, ${message.member.nickname ? message.member.nickname : message.author.username}`)
 			.addField('Are you back?', 'Go to <#415261994887938048> and run `!afk` again to turn off AFK!',true)

--- a/eventActions/citadelActions.js
+++ b/eventActions/citadelActions.js
@@ -23,8 +23,8 @@ class citadelActions {
 	static async holidayReacts(client, message) {
 		// Handle merry Christmas
 		if (
-			message.content.toLowerCase().indexOf("merry") != -1 &&
-			message.content.toLowerCase().indexOf("christmas") != -1
+			message.content.toLowerCase().indexOf('merry') != -1 &&
+			message.content.toLowerCase().indexOf('christmas') != -1
 		) {
 			var reactions = ['🎄', '☃️', '❄️'];
 			var choice = reactions[Math.floor(Math.random() * reactions.length)];

--- a/eventActions/cotwActions.js
+++ b/eventActions/cotwActions.js
@@ -1,4 +1,5 @@
 const config = require('../config.json');
+const fs = require('fs');
 
 class cotwActions {
 
@@ -87,11 +88,11 @@ class cotwActions {
 				store.set('challengeName', challengeName);
 				const emote = config.emotes.cotwReflection;
 				message.react(emote);
-				let check = await confirmUpdate(message)
+				let check = await confirmUpdate(message);
 				if (check == null) {
-					message.react(config.emotes.no)
+					message.react(config.emotes.no);
 					return message.channel.send(
-						`An error occured and the COTW was not updated.`
+						'An error occured and the COTW was not updated.'
 					);
 				}
 				else {
@@ -100,21 +101,22 @@ class cotwActions {
 					);
 				}
 			}
+
 			async function confirmUpdate(message) {
-				let path = process.cwd() + '/data/cotw.json'
-				const stats = fs.statSync(path)
-				let mtime = stats.mtime
-				let lastModified = new Date(mtime)
-				console.log(lastModified)
-				let currentDate = new Date()
-				console.log(currentDate)
-				let diff = currentDate.getTime() - lastModified.getTime()
-				let minute = 1000 * 60
+				let path = process.cwd() + '/data/cotw.json';
+				const stats = fs.statSync(path);
+				let mtime = stats.mtime;
+				let lastModified = new Date(mtime);
+				console.log(lastModified);
+				let currentDate = new Date();
+				console.log(currentDate);
+				let diff = currentDate.getTime() - lastModified.getTime();
+				let minute = 1000 * 60;
 				if (diff <= minute) {
-					return message.react(config.emotes.yes2)
+					return message.react(config.emotes.yes2);
 				}
 				else {
-					return null
+					return null;
 				}
 			}
 		}

--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -1,21 +1,22 @@
 const Discord = require('discord.js');
-// const db = require('quick.db');
 const BanWordUtils = require('../utils/banwordUtils.js');
 const config = require('../config.json');
 
 class profanityActions {
 	static async checkForProfanity(client, message) {
-		// const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
 		const bannedWordsSQL = await BanWordUtils.getBannedWords();
 
 		// check that moderation channelID is valid before attempting profanity check
 		if (client.channels.cache.get(config.channels.moderation) === undefined) {
 			console.log('Error! Moderation Channel ID in Config in likely invalid. Please verify!');
-		} else if (!bannedWordsSQL) { // ensure bannedWords is populated
+		} 
+		
+		// ensure bannedWords is populated
+		if (bannedWordsSQL.length == 0) { 
 			console.log('Error: No banned words found in database.');
 		}
 
-		if (bannedWordsSQL.some((word) => message.content.includes(word))) {
+		if (bannedWordsSQL.some((word) => message.content.toLowerCase().includes(word))) {
 			const embedMessage = new Discord.MessageEmbed()
 				.setColor('#ff0000')
 				.setTitle('🚩 Warning: Profanity detected 🚩')

--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -1,37 +1,38 @@
 const Discord = require('discord.js');
-const db = require('quick.db');
+// const db = require('quick.db');
+const BanWordUtils = require('../utils/banwordUtils.js');
 const config = require('../config.json');
 
 class profanityActions {
-  static async checkForProfanity(client, message) {
-    const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
+	static async checkForProfanity(client, message) {
+		// const bannedWords = await db.get(`bannedWords-${message.guild.id}`);
+		const bannedWordsSQL = await BanWordUtils.getBannedWords();
 
-    // check that moderation channelID is valid before attempting profanity check
-    if (client.channels.cache.get(config.channels.moderation) === undefined) {
-      console.log('Error! Moderation Channel ID in Config in likely invalid. Please verify!');
-    }
-    else if (!bannedWords) { // ensure bannedWords is populated
-      console.log('Error: No banned words found in database.');
-    }
+		// check that moderation channelID is valid before attempting profanity check
+		if (client.channels.cache.get(config.channels.moderation) === undefined) {
+			console.log('Error! Moderation Channel ID in Config in likely invalid. Please verify!');
+		} else if (!bannedWordsSQL) { // ensure bannedWords is populated
+			console.log('Error: No banned words found in database.');
+		}
 
-    if (bannedWords.some((word) => message.content.includes(word))) {
-      const embedMessage = new Discord.MessageEmbed()
-        .setColor('#ff0000')
-        .setTitle('🚩 Warning: Profanity detected 🚩')
-        .setDescription(`Profanity detected in ${message.channel}`)
-        .addField('User', message.author, true)
-        .addField('Link', `[Go to message](${message.url})`, true)
-        .addField('Message', `**${message.content}**`, true)
-        .setFooter(
-          `${message.author.username}#${message.author.discriminator}`,
-          message.author.avatarURL,
-        );
-      return client.channels.cache
-        .get(config.channels.moderation)
-        .send(embedMessage);
-    }
-    return null;
-  }
+		if (bannedWordsSQL.some((word) => message.content.includes(word))) {
+			const embedMessage = new Discord.MessageEmbed()
+				.setColor('#ff0000')
+				.setTitle('🚩 Warning: Profanity detected 🚩')
+				.setDescription(`Profanity detected in ${message.channel}`)
+				.addField('User', message.author, true)
+				.addField('Link', `[Go to message](${message.url})`, true)
+				.addField('Message', `**${message.content}**`, true)
+				.setFooter(
+					`${message.author.username}#${message.author.discriminator}`,
+					message.author.avatarURL,
+				);
+			return client.channels.cache
+				.get(config.channels.moderation)
+				.send(embedMessage);
+		}
+		return null;
+	}
 }
 
 module.exports = profanityActions;

--- a/events/message.js
+++ b/events/message.js
@@ -37,7 +37,7 @@ module.exports = async (client, message) => {
 	// Handle greetings
 	citadelActions.greetMorningOrNight(client, message);
 	// Handle holiday reactions
-  	citadelActions.holidayReacts(client, message);
+	citadelActions.holidayReacts(client, message);
 	// Handle hall of conquests
 	hocActions.reactWithLetsGo(client, message);
 	// Handle snapshots

--- a/utils/banwordUtils.js
+++ b/utils/banwordUtils.js
@@ -27,6 +27,16 @@ const getBannedWords = async () => {
 	return finalResult;
 };
 
+const getBannedWordsAndAuthors = async() => {
+	await BannedWord.sync();
+	const queryResult = await BannedWord.findAll({
+		attributes: ['word', 'userID'],
+		raw: true,
+	});
+
+	return queryResult;
+};
+
 const addWordToBannedWordTable = async (word, userID) => {
 	const isAlreadyBanned = await isBanned(word);
 
@@ -66,3 +76,4 @@ module.exports.addWordToBannedWordTable = addWordToBannedWordTable;
 module.exports.deleteWord = deleteWord;
 module.exports.isBanned = isBanned;
 module.exports.getBannedWords = getBannedWords;
+module.exports.getBannedWordsAndAuthors = getBannedWordsAndAuthors;

--- a/utils/banwordUtils.js
+++ b/utils/banwordUtils.js
@@ -1,0 +1,68 @@
+const BannedWord = require('../databaseFiles/bannedWordTable.js');
+
+const isBanned = async (word) => {
+	await BannedWord.sync();
+	const result = await BannedWord.findOne({
+		where: {
+			word,
+		},
+	});
+
+	// if it exists return TRUE, else return FALSE
+	return !(result == null);
+};
+
+const getBannedWords = async () => {
+	await BannedWord.sync();
+	const queryResult = await BannedWord.findAll({
+		attributes: ['word'],
+		raw: true,
+	});
+
+	const finalResult = [];
+	queryResult.forEach((element) => {
+		finalResult.push(element.word);
+	});
+
+	return finalResult;
+};
+
+const addWordToBannedWordTable = async (word, userID) => {
+	const isAlreadyBanned = await isBanned(word);
+
+	if (!isAlreadyBanned) {
+		BannedWord.sync().then(async () => {
+			await BannedWord.create({
+				word,
+				userID,
+			});
+		});
+
+		return `Success! Added ${word} to the blocked word list!`;
+	}
+
+	return `Failure! Cannot ban ${word}, because it is already banned!`;
+};
+
+const deleteWord = async (word) => {
+	const isAlreadyBanned = await isBanned(word);
+
+	if (!isAlreadyBanned) {
+		return 'That word isn\'t currently banned!';
+	}
+
+	BannedWord.sync().then(async () => {
+		await BannedWord.destroy({
+			where: {
+				word,
+			},
+		});
+	});
+
+	return `Success! Unbanned ${word} from the list!`;
+};
+
+module.exports.addWordToBannedWordTable = addWordToBannedWordTable;
+module.exports.deleteWord = deleteWord;
+module.exports.isBanned = isBanned;
+module.exports.getBannedWords = getBannedWords;


### PR DESCRIPTION
### Changes:
* New Sequelize model `bannedWord`
* Change `banword`/`unbanword` commands to use Sequelize
* Add the new command `listbanword`, which shows the banned words and their authors
* Store all CRUD methods for `bannedWord` in an utilitary file
* Fix linting in afk.js, there were a lot of mixed space/tabs

_**Note**: Most of it should be compatible with AirBnB linting, but I kept the original `.eslintrc.json` file._
