### PR TITLE
[FIX] Pinning reactions doesn't work as expected in #accountability-station. #171

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,8 +5,10 @@ const config = require('./config.json');
 const connect = require('./databaseFiles/connect.js');
 const remind = require('./commands/remind.js');
 
-// const client = new Discord.Client({ ws: { intents: ['GUILDS', 'GUILD_MEMBERS', 'GUILD_MESSAGES', 'GUILD_MESSAGE_REACTIONS']}});
-const client = new Discord.Client({ ws: { intents: new Discord.Intents(Discord.Intents.ALL) }});
+const client = new Discord.Client({
+	partials: ["REACTION", "MESSAGE"],
+	ws: { intents: ['GUILDS', 'GUILD_MEMBERS', 'GUILD_MESSAGES', 'GUILD_MESSAGE_REACTIONS']}
+});
 
 fs.readdir('./events/', (err, files) => {
 	if (err) return console.error(err);

--- a/app.js
+++ b/app.js
@@ -5,7 +5,8 @@ const config = require('./config.json');
 const connect = require('./databaseFiles/connect.js');
 const remind = require('./commands/remind.js');
 
-const client = new Discord.Client({ ws: { intents: ['GUILDS', 'GUILD_MEMBERS', 'GUILD_MESSAGES', 'GUILD_MESSAGE_REACTIONS']}});
+// const client = new Discord.Client({ ws: { intents: ['GUILDS', 'GUILD_MEMBERS', 'GUILD_MESSAGES', 'GUILD_MESSAGE_REACTIONS']}});
+const client = new Discord.Client({ ws: { intents: new Discord.Intents(Discord.Intents.ALL) }});
 
 fs.readdir('./events/', (err, files) => {
 	if (err) return console.error(err);

--- a/eventActions/accountabilityActions.js
+++ b/eventActions/accountabilityActions.js
@@ -25,7 +25,7 @@ class accountabilityActions {
 			const currentChannel = sentMessage.channel;
 
 			// Check if there are too many existing pins
-			currentChannel.fetchPinnedMessages().then(messages => {
+			currentChannel.messages.fetchPinned().then(messages => {
 				const numOfPins = messages.size;
 				if(numOfPins === 50){
 					currentChannel.send('**Uh oh!** This channel has reached its pin limit. Contact a Helper to purge the list.');
@@ -36,7 +36,7 @@ class accountabilityActions {
 			// Make sure a user is pinning their own message
 			if(user.id != sentMessage.author.id) return;
 
-			await currentChannel.fetchPinnedMessages().then(fetchedPins =>{
+			await currentChannel.messages.fetchPinned().then(fetchedPins =>{
 
 				// If the pushpin reaction from the bot does not exist, pin the message
 				if(!isMessagePinnedAtAll(sentMessage, fetchedPins)){
@@ -57,7 +57,7 @@ class accountabilityActions {
 					}
 
 					// Pin the message
-					sentMessage.clearReactions();
+					sentMessage.reactions.removeAll();
 					sentMessage.react(config.emotes.pinMessage);
 					sentMessage.pin();
 

--- a/eventActions/accountabilityActions.js
+++ b/eventActions/accountabilityActions.js
@@ -111,7 +111,7 @@ class accountabilityActions {
 	// Removes all pinned messages by a user
 	static async userUnpinsAllMessages(message, user){
 		if(message.channel.id === config.channels.accountability) {
-			await message.channel.fetchPinnedMessages().then(fetchedPins => {
+			await message.channel.messages.fetchPinned().then(fetchedPins => {
 
 				// We're essentially doing the same thing as unpin message, but we don't stop upon finding their most recent pin.
 				const pinMsgIterator = fetchedPins.values();

--- a/eventActions/accountabilityActions.js
+++ b/eventActions/accountabilityActions.js
@@ -84,7 +84,6 @@ class accountabilityActions {
 			let hasPinnedMessage = false;
 
 			// Get the pinned messages within a channel
-			//currentChannel.messages.fetchPinned()
 			await currentChannel.messages.fetchPinned().then(fetchedPins => {
 
 				// Check to see if they already have pinned messages

--- a/eventActions/accountabilityActions.js
+++ b/eventActions/accountabilityActions.js
@@ -84,7 +84,8 @@ class accountabilityActions {
 			let hasPinnedMessage = false;
 
 			// Get the pinned messages within a channel
-			await currentChannel.fetchPinnedMessages().then(fetchedPins => {
+			//currentChannel.messages.fetchPinned()
+			await currentChannel.messages.fetchPinned().then(fetchedPins => {
 
 				// Check to see if they already have pinned messages
 				const pinMsgIterator = fetchedPins.values();


### PR DESCRIPTION
Fixed the issue/bug from:

https://github.com/knights-of-academia/horace/projects/3#card-53700051

Issues were: 
- partials were missing from Client object creation (for messages and reaction)
- commands were using obsolete methods that don't exist anymore like `channel.fetchPinnedMessages()`. I replaced all such problems with the new style recommended by DiscordJS.

Make sure to move the card from Backlog to Review In Progress and let me know if there's anything you would like to me to fix, before merging it.