### PR TITLE
Separate 'Hall of Conquests' and 'Focused Raider' reactions in config file

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -34,6 +34,7 @@
     "acceptTOS": "✅",
     "bookmark": "🔖",
     "hocReaction": "🎉",
+    "focusedRaider": "🎉",
     "sleeplogReaction": "🛏️",
     "sleeplog": "<:log:644552324702011402>",
     "cotwVow": "⚔",

--- a/eventActions/focusedRaiderActions.js
+++ b/eventActions/focusedRaiderActions.js
@@ -4,7 +4,7 @@ class focusedRaiderActions {
 
 	static async giveRole(reaction, user){
 		// Ensure we're in the proper channel and using the proper reaction
-		if(reaction.message.channel.id == config.channels.chooseroles && reaction._emoji.name == config.emotes.hocReaction) {
+		if(reaction.message.channel.id == config.channels.chooseroles && reaction._emoji.toString() === config.emotes.focusedRaider) {
 			if(reaction.message.id != config.focusedRaiderMessageId) return;
 			// Create the role variable
 			const role = reaction.message.guild.roles.cache.find(role => role.id === config.roles.focusedraider);
@@ -22,7 +22,7 @@ class focusedRaiderActions {
 
 	static async removeRole(reaction, user){
 		// Ensure we're in the proper channel and using the proper reaction
-		if(reaction.message.channel.id == config.channels.chooseroles && reaction._emoji.name == config.emotes.hocReaction) {
+		if(reaction.message.channel.id == config.channels.chooseroles && reaction._emoji.toString() == config.emotes.focusedRaider) {
 
 			if(reaction.message.id != config.focusedRaiderMessageId) return;
 

--- a/eventActions/focusedRaiderActions.js
+++ b/eventActions/focusedRaiderActions.js
@@ -4,7 +4,7 @@ class focusedRaiderActions {
 
 	static async giveRole(reaction, user){
 		// Ensure we're in the proper channel and using the proper reaction
-		if(reaction.message.channel.id == config.channels.chooseroles && reaction._emoji.toString() === config.emotes.focusedRaider) {
+		if(reaction.message.channel.id == config.channels.chooseroles && reaction._emoji.toString() == config.emotes.focusedRaider) {
 			if(reaction.message.id != config.focusedRaiderMessageId) return;
 			// Create the role variable
 			const role = reaction.message.guild.roles.cache.find(role => role.id === config.roles.focusedraider);


### PR DESCRIPTION
Quick change that splits these emojis up in the config file, as they're used for different things.
Updated the emoji comparison in focused raider handler to take both unicode and custom emoji formats.
HoC and Focused Raider have both been tested after these changes.