### PR TITLE
Added spoiler command

### DIFF
--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -1,0 +1,14 @@
+module.exports.execute = async (client, message, args) => {
+
+	let spoilerText = '||' + args.join(' ') + '||';
+	let author = '**' + message.author.username + '**';
+
+	return await message.channel.send(`${author}\n${spoilerText}`);
+};
+
+module.exports.config = {
+	name: 'spoiler',
+	aliases: ['spoiler', 'censor'],
+	description: 'Easily have Horace to spoiler your message!',
+	usage: ['spoiler [text]','censor [text]'],
+};

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -1,7 +1,11 @@
 module.exports.execute = async (client, message, args) => {
 
-	let spoilerText = '||' + args.join(' ') + '||';
-	let author = '**' + message.author.username + '**';
+	let spoiler = args.join(' ');
+	if (spoiler.length === 0){
+		return await message.channel.send('Please include text to send as a spoilered message!\n`!spoiler [text to spoiler]`');
+	}
+	let spoilerText = '||' + spoiler + '||';
+	let author = `<@${message.author.id}>`;
 
 	return await message.channel.send(`${author}\n${spoilerText}`);
 };

--- a/eventActions/highlightActions.js
+++ b/eventActions/highlightActions.js
@@ -82,9 +82,8 @@ class highlightActions {
 
 	// Method to call that DMs a user about a message containing a highlighted phrase
 	static async sendHighlightDM(client, user, message, highlightedPhrase) {
-		const workingMessage = message;
 		const highlightsEmote = '☀️';
-		if (workingMessage.author == user) {
+		if (message.author == user) {
 			return console.log('no DM to same user');
 		}
 		else {
@@ -93,10 +92,10 @@ class highlightActions {
 				.setTitle(`${highlightsEmote} Knights of Academia Highlight Alert ${highlightsEmote}`)
 				.setDescription('One of your highlights has been triggered!')
 				.addField('Highlighted Phrase', highlightedPhrase)
-				.addField('Full Message', workingMessage)
-				.addField('From', workingMessage.author, true)
-				.addField('Link to Message', `[Jump to Message](${workingMessage.url})`, true)
-				.addField('Channel', workingMessage.channel);
+				.addField('Full Message', message)
+				.addField('From', message.author, true)
+				.addField('Link to Message', `[Jump to Message](${message.url})`, true)
+				.addField('Channel', message.channel);
 	
 			user.send(highlightNotification);
 		}

--- a/eventActions/highlightActions.js
+++ b/eventActions/highlightActions.js
@@ -84,17 +84,22 @@ class highlightActions {
 	static async sendHighlightDM(client, user, message, highlightedPhrase) {
 		const workingMessage = message;
 		const highlightsEmote = '☀️';
-		const highlightNotification = new Discord.MessageEmbed()
-			.setColor('#FFEC09')
-			.setTitle(`${highlightsEmote} Knights of Academia Highlight Alert ${highlightsEmote}`)
-			.setDescription('One of your highlights has been triggered!')
-			.addField('Highlighted Phrase', highlightedPhrase)
-			.addField('Full Message', workingMessage)
-			.addField('From', workingMessage.author, true)
-			.addField('Link to Message', `[Jump to Message](${workingMessage.url})`, true)
-			.addField('Channel', workingMessage.channel);
-
-		user.send(highlightNotification);
+		if (workingMessage.author == user) {
+			return console.log('no DM to same user');
+		}
+		else {
+			const highlightNotification = new Discord.MessageEmbed()
+				.setColor('#FFEC09')
+				.setTitle(`${highlightsEmote} Knights of Academia Highlight Alert ${highlightsEmote}`)
+				.setDescription('One of your highlights has been triggered!')
+				.addField('Highlighted Phrase', highlightedPhrase)
+				.addField('Full Message', workingMessage)
+				.addField('From', workingMessage.author, true)
+				.addField('Link to Message', `[Jump to Message](${workingMessage.url})`, true)
+				.addField('Channel', workingMessage.channel);
+	
+			user.send(highlightNotification);
+		}
 	}
 }
 


### PR DESCRIPTION
Just a small command I quickly added based on a suggestion from a KOA member. Allows the user to spoiler their message using the `!spoiler` command, which could be easier for users to discover/use than the Discord `||` implementation.

Wrote this one pretty quick so let me know if I forgot something!