### PR TITLE
Added reaction when picture posted in snapshots channel

### DIFF
--- a/eventActions/snapshotActions.js
+++ b/eventActions/snapshotActions.js
@@ -25,6 +25,9 @@ class snapshotActions {
 			// Send message to moderation log
 			client.channels.cache.get(config.channels.moderation).send(embedMessage);
 		}
+		else if (message.channel.id === config.channels.snapshots) {
+			return message.react(config.emotes.heart);
+		}
 	}
 }
 


### PR DESCRIPTION
A request from Alex. Horace now reacts with ❤️  when an image is posted to the snapshots channel.

No config update necessary, the heart was already in there.