### PR TITLE
Remove repetitive log

### DIFF
--- a/eventActions/profanityActions.js
+++ b/eventActions/profanityActions.js
@@ -12,7 +12,7 @@ class profanityActions {
 		}
 
 		if (bannedWordsSQL.length == 0) {
-			return console.log('Error: No banned words found in database.');
+			return;
 		}
 
 		if (bannedWordsSQL.some((word) => message.content.toLowerCase().includes(word))) {


### PR DESCRIPTION
When running Horace with no banned words in the database, an error message is logged to the console whenever a message is sent in the Discord server. This message does not indicate an error, and should not log - doing so unnecessarily clutters the log.