### PR TITLE
Add spacing rule for commas

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
         "space-before-blocks": "error",
         "space-infix-ops": "error",
         "newline-per-chained-call": "error",
+        "comma-spacing": "error",
         "comma-style": "error",
         "dot-notation": "error",
         "no-shadow": "error",

--- a/commands/invite.js
+++ b/commands/invite.js
@@ -22,5 +22,5 @@ module.exports.config = {
 	name: 'invite',
 	aliases: ['invite', 'discord'],
 	description: 'Want to invite a friend to the server? This will get you the invite link.',
-	usage: ['invite','invite camelot', 'invite koai'],
+	usage: ['invite', 'invite camelot', 'invite koai'],
 };

--- a/commands/listbanword.js
+++ b/commands/listbanword.js
@@ -11,7 +11,7 @@ module.exports.execute = async (client, message) => {
 	for (const element of bannedWords) {
 		const user = client.users.cache.get(element.userID);
 		const username = user.username;
-		embedMessage.addField(`${element.word}`,`added by ${username}`);
+		embedMessage.addField(`${element.word}`, `added by ${username}`);
 	}
 
 	embedMessage.setFooter('To ban more words use the !banword <word> command and to unban words use the !unbanword <word> command.');

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -13,5 +13,5 @@ module.exports.config = {
 	name: 'spoiler',
 	aliases: ['spoiler', 'censor'],
 	description: 'Easily have Horace to spoiler your message!',
-	usage: ['spoiler [text]','censor [text]'],
+	usage: ['spoiler [text]', 'censor [text]'],
 };

--- a/eventActions/tosReminderAction.js
+++ b/eventActions/tosReminderAction.js
@@ -61,7 +61,7 @@ const tosRemind = async (client) => {
 				await user.send(messageEmbed);
 			}
 			catch (err) {
-				console.error('TosReminder error: ',err);
+				console.error('TosReminder error: ', err);
 			}
 
 			try {

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -3,5 +3,5 @@ const tosReminderAction = require('../eventActions/tosReminderAction');
 
 module.exports = (client, member) => {
 	member.roles.add(member.guild.roles.cache.find((role) => role.id === Config.ROLES.INITIATE));
-	tosReminderAction.addToDatabase(member,new Date());
+	tosReminderAction.addToDatabase(member, new Date());
 };


### PR DESCRIPTION
Quick update to the linter config that enforces spacing around commas, as this has been inconsistent in PRs recently. Would rather have the linter handle it than make a comment every time