### PR TITLE
Fix bot crash when user prevents inbound DMs

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -17,9 +17,9 @@ module.exports.execute = async (client, message, args) => {
 		await discordDMWrapper.sendMessage(message.author, helpMessage).then(async () => {
 			await message.channel.send('I have sent you a private message with the command list.');
 		})
-			.catch(async (reason) => {
+			.catch((reason) => {
 				if (reason === 'DMs not allowed') {
-					await message.channel.send('I was not able to send you a message, because your DMs were disabled');
+					discordDMWrapper.sendBlockedDMsWarning(message.channel, 'the bot commands.');
 				}
 			});
 	} else if (args.length === 1) {

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,4 +1,5 @@
 const Discord = require('discord.js');
+const discordDMWrapper = require ('../helpers/discordDirectMessageWrapper');
 const { Config: { BOT: { PREFIX } } } = require('../config.js');
 
 module.exports.execute = async (client, message, args) => {
@@ -13,13 +14,14 @@ module.exports.execute = async (client, message, args) => {
 		commands.forEach((command) => {
 			helpMessage.addField(`**${PREFIX}${command.config.name}**`, `${command.config.description}`);
 		});
-		try {
-			await message.author.send(helpMessage);
+		await discordDMWrapper.sendMessage(message.author, helpMessage).then(async () => {
 			await message.channel.send('I have sent you a private message with the command list.');
-		}
-		catch (err) {
-			console.log(err);
-		}
+		})
+			.catch(async (reason) => {
+				if (reason === 'DMs not allowed') {
+					await message.channel.send('I was not able to send you a message, because your DMs were disabled');
+				}
+			});
 	} else if (args.length === 1) {
 		let command = commands.find((theCommand) =>
 			theCommand.config.name === args[0].toLowerCase() ||

--- a/commands/highlight.js
+++ b/commands/highlight.js
@@ -1,6 +1,7 @@
 const Highlights = require('../databaseFiles/highlightsTable.js');
 const Discord = require('discord.js');
 const { Config } = require('../config.js');
+const discordDMWrapper = require('../helpers/discordDirectMessageWrapper');
 
 const errHandler = (err) => {
 	console.error('Highlights sequelize error: ', err);
@@ -58,7 +59,7 @@ const addHighlight = async (keywords, user) => {
 		}
 	}).then((count) => {
 		if (count != 0) {
-			user.send('Attempted to add **`' + keywords + '`** to your highlights, but it\'s already there!');
+			discordDMWrapper.sendMessage(user, `Attempted to add '${keywords}' to your highlights, but it's already there!`).catch(() => {});
 		} else {
 			exists = false;
 		}
@@ -71,7 +72,7 @@ const addHighlight = async (keywords, user) => {
 		}).catch(errHandler);
 
 		const highlightsHelp = getHiglightAdditionReplyMsg(keywords);
-		return user.send(highlightsHelp);
+		return discordDMWrapper.sendMessage(user, highlightsHelp).catch(() => {});
 	}
 };
 
@@ -85,7 +86,7 @@ const removeHighlight = async (keywords, user) => {
 		}
 	}).then((result) => {
 		if (result == 0) {
-			user.send('You tried to remove a highlight, `' + keywords + '`, but it doesn\'t seem to exist.');
+			discordDMWrapper.sendMessage(user, `You tried to remove a highlight, '${keywords}', but it doesn't seem to exist.`).catch(() => {});
 			exists = false;
 		}
 	});
@@ -95,7 +96,7 @@ const removeHighlight = async (keywords, user) => {
 	}
 
 	const highlightsRemovalMsg = getHiglightRemovalReplyMsg(keywords);
-	return await user.send(highlightsRemovalMsg);
+	return await discordDMWrapper.sendMessage(user, highlightsRemovalMsg).catch(() => {});
 };
 
 const listHighlights = async (user) => {
@@ -106,7 +107,7 @@ const listHighlights = async (user) => {
 		}
 	}).then((result) => {
 		if (result.length == 0) {
-			user.send('_You don\'t have any highlights._ Add some with `!highlights add <keywords>`');
+			discordDMWrapper.sendMessage(user, '_You don\'t have any highlights._ Add some with `!highlights add <keywords>`').catch(() => {});
 			return;
 		}
 		for (let i = 0; i < result.length; i++) {
@@ -114,7 +115,7 @@ const listHighlights = async (user) => {
 		}
 
 		const HighlightsListMsg = getHighlightsListReplyMsg(listOfWords);
-		user.send(HighlightsListMsg);
+		discordDMWrapper.sendMessage(user, HighlightsListMsg).catch(() => {});
 	});
 };
 
@@ -126,7 +127,7 @@ module.exports.execute = async (client, message, args) => {
 
 	if (keywords.length === 0) {
 		const highlightsHelp = getHelpReply();
-		return await user.send(highlightsHelp);
+		return await discordDMWrapper.sendMessage(user, highlightsHelp).catch(() => {});
 	}
 	else if (keywords.length > 1) {
 		if (cmd === 'add') {
@@ -139,7 +140,7 @@ module.exports.execute = async (client, message, args) => {
 			return await listHighlights(user);
 		}
 		else {
-			return await user.send('Please use `!highlight add <word/phrase>` to add a new highlight. (case insensitive)');
+			return discordDMWrapper.sendMessage(user, 'Please use `!highlight add <word/phrase>` to add a new highlight. (case insensitive)').catch(() => {});
 		}
 	}
 };

--- a/commands/highlight.js
+++ b/commands/highlight.js
@@ -50,7 +50,7 @@ const getHighlightsListReplyMsg = (listOfWords) => {
 	return HighlightsListReplyMsg;
 };
 
-const addHighlight = async (keywords, user) => {
+const addHighlight = async (keywords, user, channel) => {
 	const userID = user.id;
 	let exists = true;
 	await Highlights.count({
@@ -59,7 +59,8 @@ const addHighlight = async (keywords, user) => {
 		}
 	}).then((count) => {
 		if (count != 0) {
-			discordDMWrapper.sendMessage(user, `Attempted to add '${keywords}' to your highlights, but it's already there!`).catch(() => {});
+			discordDMWrapper.sendMessage(user, `Attempted to add '${keywords}' to your highlights, but it's already there!`)
+				.catch(() => { discordDMWrapper.sendBlockedDMsWarning(channel, 'that the requested highlight is already in my list.'); });
 		} else {
 			exists = false;
 		}
@@ -72,11 +73,12 @@ const addHighlight = async (keywords, user) => {
 		}).catch(errHandler);
 
 		const highlightsHelp = getHiglightAdditionReplyMsg(keywords);
-		return discordDMWrapper.sendMessage(user, highlightsHelp).catch(() => {});
+		return discordDMWrapper.sendMessage(user, highlightsHelp)
+			.catch(() => { discordDMWrapper.sendBlockedDMsWarning(channel, 'that I have added the requested word to the list of highlights I have for you.'); });
 	}
 };
 
-const removeHighlight = async (keywords, user) => {
+const removeHighlight = async (keywords, user, channel) => {
 	const userID = user.id;
 	let exists = true;
 	await Highlights.destroy({
@@ -86,7 +88,8 @@ const removeHighlight = async (keywords, user) => {
 		}
 	}).then((result) => {
 		if (result == 0) {
-			discordDMWrapper.sendMessage(user, `You tried to remove a highlight, '${keywords}', but it doesn't seem to exist.`).catch(() => {});
+			discordDMWrapper.sendMessage(user, `You tried to remove a highlight, '${keywords}', but it doesn't seem to exist.`)
+				.catch(() => { discordDMWrapper.sendBlockedDMsWarning(channel, 'that I can\'t find the highlight in my list.'); });
 			exists = false;
 		}
 	});
@@ -96,10 +99,11 @@ const removeHighlight = async (keywords, user) => {
 	}
 
 	const highlightsRemovalMsg = getHiglightRemovalReplyMsg(keywords);
-	return await discordDMWrapper.sendMessage(user, highlightsRemovalMsg).catch(() => {});
+	return await discordDMWrapper.sendMessage(user, highlightsRemovalMsg)
+		.catch(() => { discordDMWrapper.sendBlockedDMsWarning(channel, 'that I have removed the highlight from my list.'); });
 };
 
-const listHighlights = async (user) => {
+const listHighlights = async (user, channel) => {
 	let listOfWords = new Array();
 	await Highlights.findAll({
 		where: {
@@ -107,7 +111,8 @@ const listHighlights = async (user) => {
 		}
 	}).then((result) => {
 		if (result.length == 0) {
-			discordDMWrapper.sendMessage(user, '_You don\'t have any highlights._ Add some with `!highlights add <keywords>`').catch(() => {});
+			discordDMWrapper.sendMessage(user, '_You don\'t have any highlights._ Add some with `!highlights add <keywords>`')
+				.catch(() => { discordDMWrapper.sendBlockedDMsWarning(channel, 'that you do not have any highlights.'); });
 			return;
 		}
 		for (let i = 0; i < result.length; i++) {
@@ -115,7 +120,8 @@ const listHighlights = async (user) => {
 		}
 
 		const HighlightsListMsg = getHighlightsListReplyMsg(listOfWords);
-		discordDMWrapper.sendMessage(user, HighlightsListMsg).catch(() => {});
+		discordDMWrapper.sendMessage(user, HighlightsListMsg)
+			.catch(() => { discordDMWrapper.sendBlockedDMsWarning(channel, 'the highlights I have for you in my list.'); });
 	});
 };
 
@@ -127,20 +133,24 @@ module.exports.execute = async (client, message, args) => {
 
 	if (keywords.length === 0) {
 		const highlightsHelp = getHelpReply();
-		return await discordDMWrapper.sendMessage(user, highlightsHelp).catch(() => {});
+		return await discordDMWrapper.sendMessage(user, highlightsHelp)
+			.catch(() => { discordDMWrapper.sendBlockedDMsWarning(message.channel, 'how highlights work.'); });
 	}
 	else if (keywords.length > 1) {
 		if (cmd === 'add') {
-			return await addHighlight(keywords, user);
+			return await addHighlight(keywords, user, message.channel);
 		}
 		else if (cmd === 'remove' || cmd === 'delete') {
-			return await removeHighlight(keywords, user);
+			return await removeHighlight(keywords, user, message.channel);
 		}
 		else if (cmd === 'list') {
-			return await listHighlights(user);
+			return await listHighlights(user, message.channel);
 		}
 		else {
-			return discordDMWrapper.sendMessage(user, 'Please use `!highlight add <word/phrase>` to add a new highlight. (case insensitive)').catch(() => {});
+			return discordDMWrapper.sendMessage(user, 'Please use `!highlight add <word/phrase>` to add a new highlight. (case insensitive)')
+				.catch(async () => {
+					await message.channel.send('I was not able to send you a message, because your DMs were disabled');
+				});
 		}
 	}
 };

--- a/commands/remind.js
+++ b/commands/remind.js
@@ -3,6 +3,7 @@ const Discord = require('discord.js');
 const { Config } = require('../config.js');
 
 const errors = require('../helpers/remindErrors.js');
+const discordDMWrapper = require('../helpers/discordDirectMessageWrapper');
 const remindUtils = require('../utils/remindUtils.js');
 
 const Reminder = require('../databaseFiles/remindersTable.js');
@@ -318,7 +319,7 @@ async function remind(client, date, reminder, shouldCatchUp = false) {
 		.setTitle(`${Config.EMOTES.REMINDERS} Reminder ${Config.EMOTES.REMINDERS}`)
 		.setDescription(description);
 
-	userToRemind.send(remindMessage);
+	discordDMWrapper.sendMessage(userToRemind, remindMessage).catch(() => {});
 
 	if (!reminder.dataValues.recurring) {
 		await Reminder.destroy({

--- a/commands/remind.js
+++ b/commands/remind.js
@@ -319,7 +319,11 @@ async function remind(client, date, reminder, shouldCatchUp = false) {
 		.setTitle(`${Config.EMOTES.REMINDERS} Reminder ${Config.EMOTES.REMINDERS}`)
 		.setDescription(description);
 
-	discordDMWrapper.sendMessage(userToRemind, remindMessage).catch(() => {});
+	discordDMWrapper.sendMessage(userToRemind, remindMessage)
+		.catch(() => {
+			// logging a message to console as this is a fire-and-forget reminder, not a reply to a command
+			console.log(`A reminder was meant for ${userToRemind.username}, but their DMs were disabled`);
+		});
 
 	if (!reminder.dataValues.recurring) {
 		await Reminder.destroy({

--- a/eventActions/highlightActions.js
+++ b/eventActions/highlightActions.js
@@ -1,6 +1,7 @@
 const Highlights = require('../databaseFiles/highlightsTable.js');
 const Discord = require('discord.js');
 const { Config } = require('../config.js');
+const discordDMWrapper = require('../helpers/discordDirectMessageWrapper');
 
 class highlightActions {
 	// Method to call to check a message for a highlighted message
@@ -110,7 +111,7 @@ class highlightActions {
 				.addField('Link to Message', `[Jump to Message](${message.url})`, true)
 				.addField('Channel', message.channel);
 
-			await user.send(highlightNotification);
+			await discordDMWrapper.sendMessage(user, highlightNotification).catch(() => {});
 		}
 	}
 }

--- a/eventActions/highlightActions.js
+++ b/eventActions/highlightActions.js
@@ -111,7 +111,11 @@ class highlightActions {
 				.addField('Link to Message', `[Jump to Message](${message.url})`, true)
 				.addField('Channel', message.channel);
 
-			await discordDMWrapper.sendMessage(user, highlightNotification).catch(() => {});
+			await discordDMWrapper.sendMessage(user, highlightNotification)
+				.catch(() => {
+					// logging a message to console as this is a fire-and-forget reminder, not a reply to a command
+					console.log(`A reminder was meant for ${user.username}, but their DMs were disabled`);
+				});
 		}
 	}
 }

--- a/helpers/discordDirectMessageWrapper.js
+++ b/helpers/discordDirectMessageWrapper.js
@@ -20,5 +20,6 @@ module.exports.sendMessage = async (user, message) => {
 };
 
 module.exports.sendBlockedDMsWarning = async (channel, reason) => {
-	await channel.send(`I tried to let you know ${reason}. \nI was not able to send you a message, because your DMs were disabled`);
+	await channel.send(`I tried to let you know ${reason}. \nI was not able to send you a message, because your DMs were disabled. `);
+	await channel.send('Here\'s how to allow me to direct message you!\nhttps://support.discord.com/hc/en-us/articles/217916488-Blocking-Privacy-Settings-\nInstead of blocking my messages, be sure to toggle this setting off to allow messages.');
 };

--- a/helpers/discordDirectMessageWrapper.js
+++ b/helpers/discordDirectMessageWrapper.js
@@ -18,3 +18,7 @@ module.exports.sendMessage = async (user, message) => {
 		}
 	}
 };
+
+module.exports.sendBlockedDMsWarning = async (channel, reason) => {
+	await channel.send(`I tried to let you know ${reason}. \nI was not able to send you a message, because your DMs were disabled`);
+};

--- a/helpers/discordDirectMessageWrapper.js
+++ b/helpers/discordDirectMessageWrapper.js
@@ -1,0 +1,20 @@
+/**
+ * Attempts to send a message to the user. Logs if user does not allow DMs.
+ * @param {*} user - User to which the message is to be sent
+ * @param {*} message - Message that is to be sent.
+ */
+module.exports.sendMessage = async (user, message) => {
+	try {
+		const result = await user.send(message);
+		Promise.resolve(result);
+	}
+	catch (err) {
+		if (err.code === 50007 && err.message === 'Cannot send messages to this user') {
+			console.log(`${user.username} does not allow DMs!`);
+			return Promise.reject('DMs not allowed');
+		}
+		else {
+			console.log(err);
+		}
+	}
+};


### PR DESCRIPTION
Without this fix, having a try-catch around the `user.send(message)` , if the user has DMs blocked using Server privacy settings or using the Discord settings, the bot can crash. 

This fix ensures that the commands !help, !remind and !highlight work properly when users have DMs disabled.

Also, in order to reduce code repetition a wrapper for the DM message sending mechanism has been added.

_Validation has been peformed. All tests are passing with no linting errors._