### PR TITLE
Bug/revamp info command

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -76,9 +76,11 @@ const addSearchTerm = async (message, args, term) => {
     }
     else {
         //Inform if user doesn't have authority to edit info
-        console.log(typeof message.member.roles.cache);
-        if (!message.member.roles.cache.has(Config.ROLES.GUARDIAN) || !message.member.roles.cache.has(Config.ROLES.HELPER)) {
+        if (!message.member.roles.cache.has(Config.ROLES.GUARDIAN) && !message.member.roles.cache.has(Config.ROLES.HELPER)) {
             message.channel.send('You do not have the experience to complete this command');
+        }
+        else {
+            message.channel.send('You are using the command in the wrong channel. Please use the command center for using the `!info` command');
         }
     }
 }

--- a/commands/info.js
+++ b/commands/info.js
@@ -3,6 +3,36 @@ const { Config } = require('../config.js');
 const InfoTerms = require('../databaseFiles/infoTermsTable.js');
 const SearchWords = require('../databaseFiles/searchWordsTable.js');
 
+const sendSearchTerms = async (client, message) => {
+	const delimiter = ',';
+	let theInfoTerms = new Array();
+	await InfoTerms.findAll({
+		attributes: ['term'],
+		raw: true
+	}).then((result) => {
+		for (let i = 0; i < result.length; i++) {
+			theInfoTerms.push(result[i].term);
+		}
+	});
+
+	if (theInfoTerms.length === 0) {
+		return await message.channel.send('No search terms available').catch((err) => {
+			client.channel.get(Config.CHANNELS.ERRORS).send(err);
+		});
+	}
+	else if (theInfoTerms.length > 0) {
+		const infoMessage = '__**List of available search terms:**__\n\n' + theInfoTerms.join(delimiter);
+
+		await message.author.send(infoMessage).catch((err) => {
+			client.channel.get(Config.CHANNELS.ERRORS).send(err);
+		});
+
+		return await message.channel.send('I have sent you a private message with the list of available search terms.').catch((err) => {
+			client.channel.get(Config.CHANNELS.ERRORS).send(err);
+		});
+	}
+};
+
 module.exports.execute = async (client, message, args) => {
 	const errHandler = (err) => {
 		client.channel.get(Config.CHANNELS.ERRORS).send(err);
@@ -16,36 +46,11 @@ module.exports.execute = async (client, message, args) => {
 
 	if (keywords.length === 0) {
 		// if no term or command is provided, show available search terms
-		const delimiter = ',';
-		let theInfoTerms = new Array();
-		await InfoTerms.findAll({
-			attributes: ['term'],
-			raw: true
-		}).then((result) => {
-			for (let i = 0; i < result.length; i++) {
-				theInfoTerms.push(result[i].term);
-			}
-		});
-
-		if (theInfoTerms.length === 0) {
-			return await message.channel.send('No search terms available').catch((err) => {
-				client.channel.get(Config.CHANNELS.ERRORS).send(err);
-			});
-		}
-		else if (theInfoTerms.length > 0) {
-			const infoMessage = '__**List of available search terms:**__\n\n' + theInfoTerms.join(delimiter);
-
-			await message.author.send(infoMessage).catch((err) => {
-				client.channel.get(Config.CHANNELS.ERRORS).send(err);
-			});
-
-			return await message.channel.send('I have sent you a private message with the list of available search terms.').catch((err) => {
-				client.channel.get(Config.CHANNELS.ERRORS).send(err);
-			});
-		}
+		return await sendSearchTerms(client, message);
 	}
 	else if (keywords.length > 1) {
 		if (cmd === 'add') { //Add a new term
+			// TODO: reafctor into addSearchTerm
 			if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
 				&& (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
 				const searchTerms = args[2].split(',');
@@ -94,6 +99,7 @@ module.exports.execute = async (client, message, args) => {
 			}
 		}
 		else if (cmd === 'remove') {
+			// TODO: reafctor into removeSearchTerm
 			if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
 					&& (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
 				//Remove entries
@@ -130,6 +136,7 @@ module.exports.execute = async (client, message, args) => {
 			}
 		}
 		else if (cmd === 'edit') {
+			// TODO: reafctor into editSearchTerm
 			if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
 						&& (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
 				//Update InfoTerms
@@ -160,6 +167,7 @@ module.exports.execute = async (client, message, args) => {
 			}
 		}
 		else if (cmd === 'help') {
+			// TODO: reafctor into helpWithSearchTerms
 			const infoHelp = new Discord.RichEmbed()
 				.setColor('#FF000')
 				.setTitle('Knights of Academia Info Help')

--- a/commands/info.js
+++ b/commands/info.js
@@ -82,7 +82,7 @@ const addSearchTerm = async (message, args, term) => {
     }
 }
 
-const removeSearchTerm = async (message, term) => {
+const removeSearchTerm = async (message, term, user) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
             && (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
         //Remove entries
@@ -150,6 +150,18 @@ const editSearchTerm = async (message, term) => {
     }
 }
 
+const helpWithSearchTerms = async (user) => {
+    const infoHelp = new Discord.RichEmbed()
+        .setColor('#FF000')
+        .setTitle('Knights of Academia Info Help')
+        .setDescription('Here are some commands to help you out with info!')
+        .addField('Add info', '`!info add <term> <comma,seperated,keywords> -<description>`')
+        .addField('Remove info', '`!info remove <keyword>`')
+        .addField('Edit info description', '`!info edit <keyword> -<new description>`')
+        .addField('List info terms', '`!info`');
+    return await user.send(infoHelp);
+}
+
 module.exports.execute = async (client, message, args) => {
 	const errHandler = (err) => {
 		client.channel.get(Config.CHANNELS.ERRORS).send(err);
@@ -173,19 +185,10 @@ module.exports.execute = async (client, message, args) => {
             return await removeSearchTerm(message, term);
 		}
 		else if (cmd === 'edit') {
-            return await removeSearchTerm(message, term);
+            return await removeSearchTerm(message, term, user);
 		}
 		else if (cmd === 'help') {
-			// TODO: reafctor into helpWithSearchTerms
-			const infoHelp = new Discord.RichEmbed()
-				.setColor('#FF000')
-				.setTitle('Knights of Academia Info Help')
-				.setDescription('Here are some commands to help you out with info!')
-				.addField('Add info', '`!info add <term> <comma,seperated,keywords> -<description>`')
-				.addField('Remove info', '`!info remove <keyword>`')
-				.addField('Edit info description', '`!info edit <keyword> -<new description>`')
-				.addField('List info terms', '`!info`');
-			return await user.send(infoHelp);
+            return await helpWithSearchTerms(user);
 		}
 		else {
 			let inputWord = await SearchWords.findAll({

--- a/commands/info.js
+++ b/commands/info.js
@@ -119,6 +119,37 @@ const removeSearchTerm = async (message, term) => {
     }
 }
 
+const editSearchTerm = async (message, term) => {
+    if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
+                && (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
+        //Update InfoTerms
+        let termToUpdate = await SearchWords.findAll({
+            attributes: ['term'],
+            where: {
+                keyword: term
+            },
+            raw: true
+        }).catch(errHandler);
+
+        await InfoTerms.update({
+            description: desc
+        }, {
+            where: {
+                term: termToUpdate[0].term
+            }
+        }).catch(errHandler);
+
+        //Confirm edit
+        return await message.channel.send(`The info term ${termToUpdate[0].term} has been updated!`);
+    }
+    else {
+        //Inform if user doesn't have authority to edit info
+        if (!message.member.roles.has(Config.ROLES.GUARDIAN) || !message.member.roles.has(Config.ROLES.HELPER)) {
+            message.channel.send('You do not have the experience to complete this command');
+        }
+    }
+}
+
 module.exports.execute = async (client, message, args) => {
 	const errHandler = (err) => {
 		client.channel.get(Config.CHANNELS.ERRORS).send(err);
@@ -142,35 +173,7 @@ module.exports.execute = async (client, message, args) => {
             return await removeSearchTerm(message, term);
 		}
 		else if (cmd === 'edit') {
-			// TODO: reafctor into editSearchTerm
-			if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
-						&& (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
-				//Update InfoTerms
-				let termToUpdate = await SearchWords.findAll({
-					attributes: ['term'],
-					where: {
-						keyword: term
-					},
-					raw: true
-				}).catch(errHandler);
-
-				await InfoTerms.update({
-					description: desc
-				}, {
-					where: {
-						term: termToUpdate[0].term
-					}
-				}).catch(errHandler);
-
-				//Confirm edit
-				return await message.channel.send(`The info term ${termToUpdate[0].term} has been updated!`);
-			}
-			else {
-				//Inform if user doesn't have authority to edit info
-				if (!message.member.roles.has(Config.ROLES.GUARDIAN) || !message.member.roles.has(Config.ROLES.HELPER)) {
-					message.channel.send('You do not have the experience to complete this command');
-				}
-			}
+            return await removeSearchTerm(message, term);
 		}
 		else if (cmd === 'help') {
 			// TODO: reafctor into helpWithSearchTerms

--- a/commands/info.js
+++ b/commands/info.js
@@ -27,14 +27,22 @@ module.exports.execute = async (client, message, args) => {
 			}
 		});
 
-		const infoMessage = '__**List of available search terms:**__\n\n' + theInfoTerms.join(delimiter);
+		if (theInfoTerms.length === 0) {
+			return await message.channel.send('No search terms available').catch((err) => {
+				client.channel.get(Config.CHANNELS.ERRORS).send(err);
+			});
+		}
+		else if (theInfoTerms.length > 0) {
+			const infoMessage = '__**List of available search terms:**__\n\n' + theInfoTerms.join(delimiter);
 
-		await message.author.send(infoMessage).catch((err) => {
-			client.channel.get(Config.CHANNELS.ERRORS).send(err);
-		});
-		return await message.channel.send('I have sent you a private message with the list of available search terms.').catch((err) => {
-			client.channel.get(Config.CHANNELS.ERRORS).send(err);
-		});
+			await message.author.send(infoMessage).catch((err) => {
+				client.channel.get(Config.CHANNELS.ERRORS).send(err);
+			});
+
+			return await message.channel.send('I have sent you a private message with the list of available search terms.').catch((err) => {
+				client.channel.get(Config.CHANNELS.ERRORS).send(err);
+			});
+		}
 	}
 	else if (keywords.length > 1) {
 		if (cmd === 'add') { //Add a new term

--- a/commands/info.js
+++ b/commands/info.js
@@ -35,7 +35,7 @@ const sendSearchTerms = async (client, message) => {
 
 const addSearchTerm = async (message, args, term) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
-        && (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
+        && (message.member.roles.cache.has(Config.ROLES.GUARDIAN) || message.member.roles.cache.has(Config.ROLES.HELPER))) {
         const searchTerms = args[2].split(',');
 
         let result = await InfoTerms.findAll({
@@ -76,7 +76,8 @@ const addSearchTerm = async (message, args, term) => {
     }
     else {
         //Inform if user doesn't have authority to edit info
-        if (!message.member.roles.has(Config.ROLES.GUARDIAN) || !message.member.roles.has(Config.ROLES.HELPER)) {
+        console.log(typeof message.member.roles.cache);
+        if (!message.member.roles.cache.has(Config.ROLES.GUARDIAN) || !message.member.roles.cache.has(Config.ROLES.HELPER)) {
             message.channel.send('You do not have the experience to complete this command');
         }
     }
@@ -84,7 +85,7 @@ const addSearchTerm = async (message, args, term) => {
 
 const removeSearchTerm = async (message, term, user) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
-            && (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
+            && (message.member.roles.cache.has(Config.ROLES.GUARDIAN) || message.member.roles.cache.has(Config.ROLES.HELPER))) {
         //Remove entries
         let cont = true;
         await InfoTerms.destroy({
@@ -113,7 +114,7 @@ const removeSearchTerm = async (message, term, user) => {
     }
     else {
         //Inform if user doesn't have authority to edit info
-        if (!message.member.roles.has(Config.ROLES.GUARDIAN) || !message.member.roles.has(Config.ROLES.HELPER)) {
+        if (!message.member.roles.cache.has(Config.ROLES.GUARDIAN) || !message.member.roles.cache.has(Config.ROLES.HELPER)) {
             message.channel.send('You do not have the experience to complete this command');
         }
     }
@@ -121,7 +122,7 @@ const removeSearchTerm = async (message, term, user) => {
 
 const editSearchTerm = async (message, term) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
-                && (message.member.roles.has(Config.ROLES.GUARDIAN) || message.member.roles.has(Config.ROLES.HELPER))) {
+                && (message.member.roles.cache.has(Config.ROLES.GUARDIAN) || message.member.roles.cache.has(Config.ROLES.HELPER))) {
         //Update InfoTerms
         let termToUpdate = await SearchWords.findAll({
             attributes: ['term'],
@@ -144,7 +145,7 @@ const editSearchTerm = async (message, term) => {
     }
     else {
         //Inform if user doesn't have authority to edit info
-        if (!message.member.roles.has(Config.ROLES.GUARDIAN) || !message.member.roles.has(Config.ROLES.HELPER)) {
+        if (!message.member.roles.cache.has(Config.ROLES.GUARDIAN) || !message.member.roles.cache.has(Config.ROLES.HELPER)) {
             message.channel.send('You do not have the experience to complete this command');
         }
     }

--- a/commands/info.js
+++ b/commands/info.js
@@ -33,7 +33,7 @@ const sendSearchTerms = async (client, message) => {
 	}
 };
 
-const addSearchTerm = async (message, args, term) => {
+const addSearchTerm = async (message, args, term, desc, errHandler) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
         && (message.member.roles.cache.has(Config.ROLES.GUARDIAN) || message.member.roles.cache.has(Config.ROLES.HELPER))) {
         const searchTerms = args[2].split(',');
@@ -85,7 +85,7 @@ const addSearchTerm = async (message, args, term) => {
     }
 }
 
-const removeSearchTerm = async (message, term, user) => {
+const removeSearchTerm = async (message, term, user, errHandler) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
             && (message.member.roles.cache.has(Config.ROLES.GUARDIAN) || message.member.roles.cache.has(Config.ROLES.HELPER))) {
         //Remove entries
@@ -122,7 +122,7 @@ const removeSearchTerm = async (message, term, user) => {
     }
 }
 
-const editSearchTerm = async (message, term) => {
+const editSearchTerm = async (message, term, errHandler) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
                 && (message.member.roles.cache.has(Config.ROLES.GUARDIAN) || message.member.roles.cache.has(Config.ROLES.HELPER))) {
         //Update InfoTerms
@@ -183,13 +183,13 @@ module.exports.execute = async (client, message, args) => {
 	}
 	else if (keywords.length > 1) {
 		if (cmd === 'add') { //Add a new term
-            return await addSearchTerm(message, args, term);
+            return await addSearchTerm(message, args, term, desc, errHandler);
 		}
 		else if (cmd === 'remove') {
-            return await removeSearchTerm(message, term);
+            return await removeSearchTerm(message, term, errHandler);
 		}
 		else if (cmd === 'edit') {
-            return await removeSearchTerm(message, term, user);
+            return await removeSearchTerm(message, term, user, errHandler);
 		}
 		else if (cmd === 'help') {
             return await helpWithSearchTerms(user);

--- a/commands/info.js
+++ b/commands/info.js
@@ -122,7 +122,7 @@ const removeSearchTerm = async (message, term, user, errHandler) => {
     }
 }
 
-const editSearchTerm = async (message, term, errHandler) => {
+const editSearchTerm = async (message, term, desc, errHandler) => {
     if (message.channel.id === Config.CHANNELS.COMMAND_CENTER
                 && (message.member.roles.cache.has(Config.ROLES.GUARDIAN) || message.member.roles.cache.has(Config.ROLES.HELPER))) {
         //Update InfoTerms
@@ -154,7 +154,6 @@ const editSearchTerm = async (message, term, errHandler) => {
 }
 
 const helpWithSearchTerms = async (user) => {
-    // TODO: TypeError: Discord.RichEmbed is not a constructor
     const infoHelp = new Discord.MessageEmbed()
         .setColor('#FF000')
         .setTitle('Knights of Academia Info Help')
@@ -189,7 +188,7 @@ module.exports.execute = async (client, message, args) => {
             return await removeSearchTerm(message, term, errHandler);
 		}
 		else if (cmd === 'edit') {
-            return await removeSearchTerm(message, term, user, errHandler);
+            return await editSearchTerm(message, term, desc, errHandler);
 		}
 		else if (cmd === 'help') {
             return await helpWithSearchTerms(user);

--- a/commands/info.js
+++ b/commands/info.js
@@ -27,7 +27,7 @@ module.exports.execute = async (client, message, args) => {
 			}
 		});
 
-		const infoMessage = '___**List of available search terms:**__\n\n' + theInfoTerms.join(delimiter);
+		const infoMessage = '__**List of available search terms:**__\n\n' + theInfoTerms.join(delimiter);
 
 		await message.author.send(infoMessage).catch((err) => {
 			client.channel.get(Config.CHANNELS.ERRORS).send(err);

--- a/commands/info.js
+++ b/commands/info.js
@@ -154,6 +154,7 @@ const editSearchTerm = async (message, term) => {
 }
 
 const helpWithSearchTerms = async (user) => {
+    // TODO: TypeError: Discord.RichEmbed is not a constructor
     const infoHelp = new Discord.RichEmbed()
         .setColor('#FF000')
         .setTitle('Knights of Academia Info Help')

--- a/commands/info.js
+++ b/commands/info.js
@@ -155,7 +155,7 @@ const editSearchTerm = async (message, term) => {
 
 const helpWithSearchTerms = async (user) => {
     // TODO: TypeError: Discord.RichEmbed is not a constructor
-    const infoHelp = new Discord.RichEmbed()
+    const infoHelp = new Discord.MessageEmbed()
         .setColor('#FF000')
         .setTitle('Knights of Academia Info Help')
         .setDescription('Here are some commands to help you out with info!')
@@ -215,7 +215,7 @@ module.exports.execute = async (client, message, args) => {
 				return await message.channel.send(`I dont know about ${cmd} yet, can you teach me?`);
 			}
 
-			const response = new Discord.RichEmbed()
+			const response = new Discord.MessageEmbed()
 				.setTitle(result[0].term)
 				.setDescription(result[0].description);
 			return await message.channel.send(response);


### PR DESCRIPTION
# WIP

**What**
Puts the `!info` command into a (buggy yet) functional state. WIP fix for #260.

**How**
- Refactor `!info` command
- Update/replace outdated Discord.js classes/constructor for newly supported ones

**Testing**
- [x] Administrative commands (i.e. **add, remove, and edit**) can only be executed in the #command-center
- [x] Administrative commands (i.e. **add, remove, and edit**) can only be executed by guardians or helpers
- [x] Single `!info` returns list of available terms or appropriate message (if no terms)
- [x] `!info add <term> <comma,seperated,keywords> -<description>` command adds a term
- [x] `!info remove <keyword>` command removes a term
- [x] `!info edit <keyword> -<new description>` command edits a term
- [ ] Description of a term allows formatting (emotes, spaces, line breaks, etc.)

**TODOs**
- [ ] Decide if informative `!info` commands (i.e. non-administrative commands such as **add, remove, edit**) should be executable from any channel or only the command center and/or users with specific role(s). Fix/update code accordingly.
- [ ] Currently, the `!info edit` command can only be called by using the first keyword (as opposed to the term or any other keyword) and can only be used to update the term's description. Decide if this is the desired behavior. Fix/update code accordingly.
- [ ] Agree/decide on the use-case for the `!info` command (unclear from documentation and from issue #260) in particular the difference between **term** and **keywords** (as pointed out in #260).
- [ ] Once agreement/decision on the use-case (previous item), update this TODOs list accordingly, if needed.
- [ ] Update error messages according to its cause (e.g. `!info edit` in prohibited channel raises "You do not have the experience to complete this command" instead of "You are using the command in the wrong channel").