### PR TITLE
fix: do not send help message in pom bank along with pom bot

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -1,10 +1,15 @@
 const Discord = require('discord.js');
 const discordDMWrapper = require ('../helpers/discordDirectMessageWrapper');
 const { Config: { BOT: { PREFIX } } } = require('../config.js');
+const { Config: { CHANNELS: { POM_BANK } } } = require('../config.js');
 
 module.exports.execute = async (client, message, args) => {
 	let commands = client.commands;
 	let commandNames = [];
+
+	if (message.channel.id == POM_BANK) {
+		return;
+	}
 
 	if (!args || args.length === 0) {
 		let helpMessage = new Discord.MessageEmbed()

--- a/config.js
+++ b/config.js
@@ -63,6 +63,7 @@ const config = {
 		'CONTENT_NOTIFIER': process.env.C_CONTENT_NOTIFER,
 		'ERRORS': process.env.C_ERRORS,
 		'FORBIDDEN_HIGHLIGHT_CHANNELS': commaSepToArray(process.env.C_FORBIDDEN_HIGHLIGHT_CHANNELS),
+		'POM_BANK': process.env.C_POM_BANK,
 	},
 
 	// Discord emotes. Unicode emotes can be specified in the config directly,


### PR DESCRIPTION
Solves a bug that causes *both* pom bot and Horace to respond to !help.

I have not been able to test this myself, as sqlite3's build process fails on my machine (Mac, M1) when running `npm i` - if anyone can give this a test that'd be much appreciated.

Required a modification to .env - add a `C_POM_BANK` variable with the value set to the "blocked" channel's ID.